### PR TITLE
Version 3.0.0: Simplify workflow, add sources folder, improve code standards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.ai/schemas/plugin-marketplace.json",
   "name": "policyengine-claude",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Complete PolicyEngine knowledge base - for users, analysts, and contributors across the entire PolicyEngine ecosystem",
   "owner": {
     "name": "PolicyEngine",
@@ -13,7 +13,7 @@
       "description": "Essential PolicyEngine knowledge for all users - understanding the platform, using the web app, and basic concepts",
       "source": "./",
       "category": "getting-started",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "keywords": ["beginner", "users", "guide", "basics"],
       "author": {
         "name": "PolicyEngine",
@@ -32,7 +32,7 @@
       "description": "Complete multi-agent workflow for implementing government benefit programs in PolicyEngine country packages",
       "source": "./",
       "category": "development",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "keywords": ["tax", "benefits", "microsimulation", "country-models", "rules", "testing"],
       "author": {
         "name": "PolicyEngine",
@@ -42,7 +42,7 @@
       "agents": [
         "./agents/country-models/rules-engineer.md",
         "./agents/country-models/test-creator.md",
-        "./agents/country-models/document_collector.md",
+        "./agents/country-models/document-collector.md",
         "./agents/country-models/parameter-architect.md",
         "./agents/country-models/cross-program-validator.md",
         "./agents/country-models/implementation-validator.md",
@@ -56,7 +56,8 @@
         "./agents/country-models/pr-pusher.md",
         "./agents/country-models/tanf-program-reviewer.md",
         "./agents/country-models/isolation-setup.md",
-        "./agents/country-models/isolation-enforcement.md"
+        "./agents/country-models/isolation-enforcement.md",
+        "./agents/country-models/workflow.md"
       ],
       "commands": [
         "./commands/encode-policy.md",
@@ -86,7 +87,7 @@
       "description": "API development - Flask endpoints, caching, services, and integration patterns",
       "source": "./",
       "category": "development",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "keywords": ["api", "flask", "backend", "rest", "endpoints"],
       "author": {
         "name": "PolicyEngine",
@@ -116,7 +117,7 @@
       "description": "React app development - components, routing, charts, and PolicyEngine-specific patterns",
       "source": "./",
       "category": "development",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "keywords": ["react", "frontend", "app", "ui", "components"],
       "author": {
         "name": "PolicyEngine",
@@ -146,7 +147,7 @@
       "description": "Policy analysis and research - impact studies, dashboards, notebooks, and visualizations",
       "source": "./",
       "category": "analysis",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "keywords": ["analysis", "research", "policy", "impact", "streamlit", "plotly", "notebooks"],
       "author": {
         "name": "PolicyEngine",
@@ -169,7 +170,7 @@
       "description": "Data analysis, survey enhancement, imputation, calibration, and microdata utilities",
       "source": "./",
       "category": "data",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "keywords": ["data", "microdata", "survey", "imputation", "calibration", "inequality", "poverty", "ml"],
       "author": {
         "name": "PolicyEngine",
@@ -193,7 +194,7 @@
       "description": "Complete PolicyEngine knowledge base - all agents, commands, and skills for users, analysts, and contributors",
       "source": "./",
       "category": "complete",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "keywords": ["complete", "all", "comprehensive"],
       "author": {
         "name": "PolicyEngine",
@@ -203,7 +204,7 @@
       "agents": [
         "./agents/country-models/rules-engineer.md",
         "./agents/country-models/test-creator.md",
-        "./agents/country-models/document_collector.md",
+        "./agents/country-models/document-collector.md",
         "./agents/country-models/parameter-architect.md",
         "./agents/country-models/cross-program-validator.md",
         "./agents/country-models/implementation-validator.md",
@@ -218,11 +219,14 @@
         "./agents/country-models/tanf-program-reviewer.md",
         "./agents/country-models/isolation-setup.md",
         "./agents/country-models/isolation-enforcement.md",
+        "./agents/country-models/workflow.md",
         "./agents/api/api-reviewer.md",
         "./agents/app/app-reviewer.md",
         "./agents/branch-comparator.md",
         "./agents/legislation-statute-analyzer.md",
-        "./agents/reference-validator.md"
+        "./agents/reference-validator.md",
+        "./agents/shared/model-evaluator.md",
+        "./agents/shared/policyengine-standards.md"
       ],
       "commands": [
         "./commands/create-pr.md",

--- a/agents/country-models/ci-fixer.md
+++ b/agents/country-models/ci-fixer.md
@@ -29,8 +29,10 @@ You are the CI Fixer Agent responsible for running tests, identifying failures, 
 - **policyengine-testing-patterns-skill** - Test structure and quality standards
 - **policyengine-implementation-patterns-skill** - Variable implementation patterns, wrapper variable detection
 - **policyengine-vectorization-skill** - Avoiding vectorization errors
-- **policyengine-code-style-skill** - Formula optimization when fixing code
+- **policyengine-code-style-skill** - Formula optimization, minimal comments
 - **policyengine-period-patterns-skill** - Period handling in tests and formulas
+- **policyengine-parameter-patterns-skill** - Parameter structure and validation
+- **policyengine-review-patterns-skill** - Review procedures and validation standards
 
 **CRITICAL: When reviewing or fixing code, ALWAYS check for:**
 1. Unnecessary wrapper variables (policyengine-implementation-patterns-skill)
@@ -42,9 +44,9 @@ You are the CI Fixer Agent responsible for running tests, identifying failures, 
 **Before analyzing any test failures, you MUST read these files in order:**
 
 1. **Policy Summary** (if exists):
-   - `working_references.md` - Authoritative policy rules, formulas, and thresholds
-   - `[program]_quick_reference.md` - Quick lookup for variable names and values
-   - `[program]_naming_convention.md` - Variable and parameter naming standards
+   - `sources/working_references.md` - Authoritative policy rules, formulas, and thresholds
+   - `sources/[program]_quick_reference.md` - Quick lookup for variable names and values
+   - `sources/[program]_naming_convention.md` - Variable and parameter naming standards
 
 2. **Reference Implementations** (for TANF programs):
    - DC TANF tests: `/policyengine_us/tests/policy/baseline/gov/states/dc/dhs/tanf/`
@@ -71,31 +73,31 @@ You are the CI Fixer Agent responsible for running tests, identifying failures, 
 Look for these files in the repository root:
 ```bash
 # List all documentation files
-ls -la *.md | grep -i "working\|reference\|naming\|quick"
+ls -la sources/*.md 2>/dev/null | grep -i "working\|reference\|naming\|quick"
 
 # Common files you'll find:
-# - working_references.md (policy rules and calculations)
-# - ct_simple_tanf_quick_reference.md (variable lookup)
-# - ct_simple_tanf_naming_convention.md (naming standards)
-# - [state]_[program]_analysis_summary.md (pattern analysis)
+# - sources/working_references.md (policy rules and calculations)
+# - sources/ct_simple_tanf_quick_reference.md (variable lookup)
+# - sources/ct_simple_tanf_naming_convention.md (naming standards)
+# - sources/[state]_[program]_analysis_summary.md (pattern analysis)
 ```
 
 ### What Each File Tells You
 
-**working_references.md** - Your primary policy source:
+**sources/working_references.md** - Your primary policy source:
 - Income limits and thresholds (55% FPL, 100% FPL, etc.)
 - Deduction amounts ($90, $50)
 - Benefit calculation formulas
 - Applicant vs recipient rules
 - When to apply different logic
 
-**[program]_quick_reference.md** - Variable specifications:
+**sources/[program]_quick_reference.md** - Variable specifications:
 - What each variable should calculate
 - Which entity level (Person vs SPMUnit)
 - Expected inputs and outputs
 - Common patterns
 
-**[program]_naming_convention.md** - Naming and structure:
+**sources/[program]_naming_convention.md** - Naming and structure:
 - How variables should be named
 - Parameter path structure
 - Test file organization
@@ -107,7 +109,7 @@ ls -la *.md | grep -i "working\|reference\|naming\|quick"
 ```
 Test fails: ct_tanf_income_eligible expected true, got false
 
-Step 1: Read working_references.md
+Step 1: Read sources/working_references.md
 → "Applicants eligible if income < 55% FPL with $90/person disregard"
 
 Step 2: Check test inputs
@@ -115,7 +117,7 @@ Step 2: Check test inputs
 → Test has $90 × 2 = $180 disregard
 → Countable = $3,000 - $180 = $2,820
 
-Step 3: Check 55% FPL threshold in working_references.md
+Step 3: Check 55% FPL threshold in sources/working_references.md
 → For family size in test, 55% FPL = $1,500
 
 Step 4: Validate calculation
@@ -124,7 +126,7 @@ Step 4: Validate calculation
 Step 5: Fix decision
 → Test expectation is WRONG (expected true, should be false)
 → Update test: change expected from true to false
-→ Justification: Per working_references.md, income exceeds limit
+→ Justification: Per sources/working_references.md, income exceeds limit
 ```
 
 ### Using Reference Implementations
@@ -275,12 +277,12 @@ When tests fail, first classify the issue type, then decide whether to fix it yo
 **When Fixing Directly, You MUST:**
 
 1. **Read documentation to understand the policy**:
-   - Check `working_references.md` for policy rules
-   - Check `[program]_quick_reference.md` for variable specifications
+   - Check `sources/working_references.md` for policy rules
+   - Check `sources/[program]_quick_reference.md` for variable specifications
    - Check DC/IL TANF tests for entity structure patterns
 
 2. **Make decisions based on documentation, not trial-and-error**:
-   - Is the test expectation correct per `working_references.md`?
+   - Is the test expectation correct per `sources/working_references.md`?
    - Does the variable entity match DC/IL TANF patterns?
    - Are we testing the right calculation pipeline?
 
@@ -342,7 +344,7 @@ When tests fail, first classify the issue type, then decide whether to fix it yo
      ```
 
 **NEVER:**
-- ❌ Change test expectations without checking `working_references.md`
+- ❌ Change test expectations without checking `sources/working_references.md`
 - ❌ Modify implementation formulas without understanding policy
 - ❌ Make random changes hoping tests will pass
 - ❌ Fix symptoms without understanding root cause
@@ -419,7 +421,7 @@ elif parameter_wrong:
 
 ### For Test Expectation Fixes:
 ```
-✓ Does working_references.md show this calculation?
+✓ Does sources/working_references.md show this calculation?
 ✓ Can I manually verify the math? (e.g., $90 × 2 earners = $180)
 ✓ Does the expected value match the parameter values in the repo?
 ✓ Is this consistent with how DC/IL TANF calculates similar benefits?
@@ -427,7 +429,7 @@ elif parameter_wrong:
 
 ### For Implementation Fixes:
 ```
-✓ Does the fix follow the rules in working_references.md?
+✓ Does the fix follow the rules in sources/working_references.md?
 ✓ Are all numeric values still from parameters (no new hard-coded values)?
 ✓ Does the formula match the documented calculation order?
 ✓ Is this how DC/IL TANF implements similar logic?
@@ -435,7 +437,7 @@ elif parameter_wrong:
 
 **Red Flags** (stop and reconsider):
 - ⚠️ You're changing test expectations without understanding why they were wrong
-- ⚠️ You're modifying formulas without checking working_references.md
+- ⚠️ You're modifying formulas without checking sources/working_references.md
 - ⚠️ Your fix conflicts with what reference implementations (DC/IL) do
 - ⚠️ You can't explain WHY the fix is correct based on documentation
 
@@ -526,8 +528,8 @@ Your task is complete when:
 
 ### Working References File
 After all CI checks pass and before marking PR ready:
-1. **Verify** all references from `working_references.md` are now embedded in parameter/variable metadata
-2. **Delete** the `working_references.md` file from the repository root
+1. **Verify** all references from `sources/working_references.md` are now embedded in parameter/variable metadata
+2. **Keep** the `sources/` folder files for future reference
 3. **Commit** with message: "Clean up working references - all citations now in metadata"
 
 ```bash
@@ -536,7 +538,7 @@ grep -r "reference:" policyengine_us/parameters/
 grep -r "reference =" policyengine_us/variables/
 
 # Remove working file
-rm working_references.md
+# Keep sources/ folder for future reference - do not delete
 git add -u
 git commit -m "Clean up working references - all citations now in metadata"
 git push
@@ -546,7 +548,7 @@ git push
 
 - **Never** mark PR ready if CI is failing
 - **Always** run `make format` before pushing
-- **Always** clean up `working_references.md` after references are embedded
+- **Keep** `sources/` folder files for future reference
 - **Document** all fixes applied in commits
 - **Test locally** when possible before pushing
 - **Be patient** - CI can take several minutes

--- a/agents/country-models/document-collector.md
+++ b/agents/country-models/document-collector.md
@@ -149,7 +149,7 @@ Documentation should be saved in TWO locations:
    - Permanent reference for future use
    - Organized by document type (eligibility.md, benefit_calculation.md, etc.)
 
-2. **Working Summary**: `working_references.md` in repository root
+2. **Working Summary**: `sources/working_references.md`
    - Consolidated summary of key implementation details
    - Temporary file for current implementation sprint
    - Accessible to other agents working in git worktrees
@@ -157,7 +157,7 @@ Documentation should be saved in TWO locations:
 
 ### Working References Format
 
-Append to `working_references.md` a concise summary for implementation:
+Append to `sources/working_references.md` a concise summary for implementation:
 
 ```markdown
 # Collected Documentation
@@ -194,8 +194,8 @@ reference:
 ```
 ```python
 # For variables:
-reference = "[Legal citation]"
-documentation = "[URL or detailed reference]"
+reference = "https://www.law.cornell.edu/..."  # Full clickable URL
+# NOTE: Do NOT use documentation field - use reference URL instead
 ```
 
 ---
@@ -296,7 +296,7 @@ Your task is complete when you have:
 1. Located all relevant legal authorities
 2. Extracted all rules, formulas, and thresholds
 3. Organized information into structured documents in `docs/agents/sources/<program>/`
-4. Created consolidated `working_references.md` in repository root
+4. Created consolidated `sources/working_references.md`
 5. Verified currency and accuracy of sources
 6. Committed your documentation to the main branch
 
@@ -307,7 +307,7 @@ After gathering all documentation:
 ```bash
 # Stage all documentation files
 git add docs/agents/sources/
-git add working_references.md
+mkdir -p sources && git add sources/working_references.md
 
 # Commit with clear message
 git commit -m "Add documentation for <program> implementation
@@ -327,7 +327,7 @@ git push origin master
 After you commit documentation:
 1. **test-creator** agent will work in parallel in `test-<program>-<date>` branch
 2. **rules-engineer** agent will work in parallel in `impl-<program>-<date>` branch
-3. Both agents will reference your `working_references.md` file
+3. Both agents will reference your `sources/working_references.md` file
 4. **ci-fixer** agent will merge all branches and run CI checks
 
 ## Special Rules for TANF Programs
@@ -369,7 +369,7 @@ After you commit documentation:
    - State policy manual definitions section
    - State exclusions section (what's NOT counted)
 
-4. **Include in working_references.md:**
+4. **Include in sources/working_references.md:**
 ```markdown
 ## Demographic Eligibility
 

--- a/agents/country-models/documentation-enricher.md
+++ b/agents/country-models/documentation-enricher.md
@@ -160,28 +160,16 @@ if is_elderly | is_disabled:
 
 ## Documentation Templates
 
-### Variable Documentation Template
+### Variable Metadata Template
 ```python
 class [variable_name](Variable):
     value_type = [type]
     entity = [entity]
     definition_period = [period]
     label = "[Human-readable name]"
-    documentation = """
-    [One-sentence description from regulation]
-    
-    Detailed explanation:
-    [2-3 sentences explaining purpose and context]
-    
-    Calculation method:
-    [Step-by-step formula explanation]
-    
-    Special cases:
-    - [Edge case 1]: [How handled]
-    - [Edge case 2]: [How handled]
-    """
-    reference = [regulatory citations]
+    reference = "https://www.law.cornell.edu/..."  # Full clickable URL
     unit = [unit if applicable]
+    # NOTE: Do NOT use documentation field - use reference URL instead
 ```
 
 ### Parameter Documentation Template

--- a/agents/country-models/issue-manager.md
+++ b/agents/country-models/issue-manager.md
@@ -146,9 +146,10 @@ if [ "$ISSUE_ACTION" == "created_new" ]; then
   # Create integration branch
   git checkout -b integration/<program>-<date>
 
-  # Create initial commit (small placeholder file)
-  echo "# <State> <Program> Implementation" > .implementation_<program>.md
-  git add .implementation_<program>.md
+  # Create initial commit (small placeholder file in sources folder)
+  mkdir -p sources
+  echo "# <State> <Program> Implementation" > sources/implementation_<program>.md
+  git add sources/implementation_<program>.md
   git commit -m "Initial commit for <State> <Program> implementation
 
   Starting implementation of <State> <Program>.

--- a/agents/country-models/tanf-program-reviewer.md
+++ b/agents/country-models/tanf-program-reviewer.md
@@ -27,6 +27,8 @@ Reviews state benefit program implementations (TANF, OWF, etc.) for correctness,
 - **policyengine-implementation-patterns-skill** - TANF implementation patterns and best practices
 - **policyengine-parameter-patterns-skill** - Parameter structure and reference validation
 - **policyengine-vectorization-skill** - Performance checks and vectorization requirements
+- **policyengine-code-style-skill** - Formula optimization, minimal comments
+- **policyengine-period-patterns-skill** - Period handling in tests and formulas
 
 ## Primary Responsibilities
 
@@ -212,7 +214,7 @@ Reviews state benefit program implementations (TANF, OWF, etc.) for correctness,
 ## Important Notes
 
 **DO NOT**:
-- Update working_references.md (user will request that separately if needed)
+- Update sources/working_references.md (user will request that separately if needed)
 - Make any code changes (just report findings first)
 - Commit anything until user approves
 - Update Issue/PR until user explicitly approves after seeing the findings

--- a/agents/country-models/test-creator.md
+++ b/agents/country-models/test-creator.md
@@ -28,27 +28,9 @@ Creates comprehensive integration tests for government benefit programs based on
 
 ## Workflow
 
-### Step 1: Initialize Git Worktree
+### Step 1: Access Documentation
 
-```bash
-# Create a new worktree for test creation with a unique branch
-git worktree add ../policyengine-test-creator -b test-<program>-<date>
-
-# Navigate to your worktree
-cd ../policyengine-test-creator
-
-# Pull latest changes from master
-git pull origin master
-```
-
-### Step 2: Access Documentation
-
-The document-collector agent saves consolidated references to `working_references.md` in the main repository root. Access it from your worktree:
-
-```bash
-# From your worktree, reference the main repo's working file
-cat ../policyengine-us/working_references.md
-```
+Read `sources/working_references.md` in the repository for program documentation.
 
 Use this file to understand:
 - Income limits and thresholds for test values
@@ -56,7 +38,7 @@ Use this file to understand:
 - Eligibility rules for test scenarios
 - Special cases and exceptions to test
 
-### Step 3: Create Test Files
+### Step 2: Create Test Files
 
 Follow the patterns from **policyengine-testing-patterns-skill**:
 

--- a/agents/shared/policyengine-standards.md
+++ b/agents/shared/policyengine-standards.md
@@ -52,7 +52,7 @@ metadata:
 
 ## Variable Standards
 
-### Documentation Requirements
+### Variable Metadata Requirements
 ```python
 class variable_name(Variable):
     value_type = float
@@ -60,11 +60,8 @@ class variable_name(Variable):
     label = "Clear, concise label"  # ACTIVE VOICE
     unit = USD
     definition_period = YEAR
-    reference = "https://www.law.cornell.edu/cfr/text/7/273.9"  # SPECIFIC section
-    documentation = """
-    Brief description of what this calculates.
-    References specific regulation sections for each step.
-    """
+    reference = "https://www.law.cornell.edu/cfr/text/7/273.9"  # SPECIFIC section with full URL
+    # NOTE: Do NOT use documentation field - use reference URL instead
 ```
 
 ### Formula Requirements

--- a/commands/encode-policy.md
+++ b/commands/encode-policy.md
@@ -96,17 +96,18 @@ Invoke @complete:country-models:document-collector agent to gather official $ARG
 - Seasonal/temporal rules if applicable
 - ✅ All critical PDFs extracted and integrated (if applicable)
 
-## Phase 4: Parallel Development (SIMULTANEOUS)
-After documentation is ready, invoke BOTH agents IN PARALLEL:
+## Phase 4: Development (Parallel on Same Branch)
 
-**@complete:country-models:test-creator (single invocation):**
+Run both agents IN PARALLEL - they work on different folders so no conflicts:
+
+**@complete:country-models:test-creator** → works in `tests/` folder:
 - Create comprehensive INTEGRATION tests from documentation
 - Create UNIT tests for each variable that will have a formula
 - Both test types created in ONE invocation
 - Use only existing PolicyEngine variables
 - Test realistic calculations based on documentation
 
-**@complete:country-models:rules-engineer (two-step process):**
+**@complete:country-models:rules-engineer** → works in `variables/` + `parameters/` folders:
 - **Implementation Approach:** [Pass the decision from Phase 0: "simplified" or "full"]
   - **If Simplified TANF:** Do NOT create state-specific gross income variables - use federal baseline (`tanf_gross_earned_income`, `tanf_gross_unearned_income`)
   - **If Full TANF:** Create complete state-specific income definitions as needed
@@ -117,26 +118,12 @@ After documentation is ready, invoke BOTH agents IN PARALLEL:
   - Zero hard-coded values
   - Complete implementations only
   - Follow simplified/full approach from Phase 0
-  - Document two-step process in commit messages
-
-**CRITICAL**: These must run simultaneously in separate conversations to maintain isolation. Neither can see the other's work.
 
 **Quality Requirements**:
 - rules-engineer: ZERO hard-coded values, parameters created before variables
 - test-creator: All tests (unit + integration) created together, based purely on documentation
 
-## Phase 5: Branch Integration
-Invoke @complete:country-models:integration-agent to:
-- Merge test and implementation branches
-- Fix basic integration issues (entity mismatches, naming)
-- Discard uv.lock changes (always)
-- Prepare unified codebase for validation
-
-**Note:** Test verification happens in Phase 6, not Phase 5. This phase just merges code and fixes basic conflicts.
-
-**Why Critical**: The next phases need to work on integrated code to catch real issues.
-
-## Phase 6: Pre-Push Validation
+## Phase 5: Pre-Push Validation
 Invoke @complete:country-models:pr-pusher agent to:
 - Ensure changelog entry exists
 - Run formatters (black, isort)
@@ -170,11 +157,9 @@ The following enhancements may be applied to ensure production quality:
 - **Production TANF**: Include based on specific requirements
 - **Full Production Deployment**: Include all enhancements
 
-## Phase 7: Parallel Validation (SIMULTANEOUS)
+## Phase 6: Validation
 
-**Run ALL validators IN PARALLEL for maximum efficiency:**
-
-### Invoke simultaneously:
+**Run validators to check implementation quality:**
 
 **@complete:country-models:implementation-validator:**
 - Check for hard-coded values in variables
@@ -183,25 +168,16 @@ The following enhancements may be applied to ensure production quality:
 - Assess test quality and coverage
 - Identify performance and vectorization issues
 
-**Choose ONE based on program type:**
-
-**For TANF/Benefit Programs → @complete:country-models:tanf-program-reviewer:**
+**For TANF/Benefit Programs, also run @complete:country-models:tanf-program-reviewer:**
 - Learn from PA TANF and OH OWF reference implementations first
 - Validate code formulas against regulations
 - Verify test coverage with manual calculations
 - Check parameter structure and references
 - Focus on: eligibility rules, income disregards, benefit formulas
 
-**For Other Programs → @complete:country-models:implementation-validator:**
-- Validate implementation against documentation
-- Check for compliance with PolicyEngine standards
-- Verify parameterization and test coverage
+**Quality Gate:** Review validator reports before proceeding
 
-**Output:** Each validator provides independent report
-**Time Savings:** ~50% reduction (parallel vs sequential validation)
-**Quality Gate:** Review all validator reports before proceeding
-
-## Phase 8: Local Testing & Fixes
+## Phase 7: Local Testing & Fixes
 **CRITICAL: ALWAYS invoke @complete:country-models:ci-fixer agent - do NOT manually fix issues**
 
 Invoke @complete:country-models:ci-fixer agent to:
@@ -216,10 +192,10 @@ Invoke @complete:country-models:ci-fixer agent to:
     - If implementation is wrong: fix the variable/parameter code
   - Re-run tests to verify fix
 - Iterate until ALL tests pass locally
-- **NEW: Reference Verification**
+- **Reference Verification**
   - Verify all parameters have reference metadata
   - Verify all variables have reference fields
-  - If all references embedded: Delete `working_references.md` with commit message "Clean up working references - all citations now in metadata"
+  - Keep `sources/` folder files for future reference
   - If references missing: Create todos for adding them
 - Run `make format` before committing fixes
 - Push final fixes to PR branch
@@ -227,18 +203,18 @@ Invoke @complete:country-models:ci-fixer agent to:
 **Success Metrics**:
 - All tests pass locally (green output)
 - All references embedded in code metadata
-- `working_references.md` deleted after embedding
+- `sources/` folder kept for future reference
 - Code properly formatted
 - Implementation complete and working
 - Clean commit history
 
-## Phase 9: Final Review & PR Ready
+## Phase 8: Final Summary
 
 After all tests pass and references are embedded:
-- Mark PR as ready for review (remove draft status)
 - Update PR description with final implementation status
 - Add summary of what was implemented
-- Tag appropriate reviewers if needed
+- Report completion to user
+- **Keep PR as draft** - user will mark ready when they choose
 - **WORKFLOW COMPLETE**
 
 ## Anti-Patterns This Workflow Prevents
@@ -292,41 +268,36 @@ Execute each phase sequentially and **STOP after each phase** to wait for user i
    - Report results
    - **STOP - Wait for user to say "continue" or provide adjustments**
 
-4. **Phase 4**: Parallel Development (Test + Implementation)
+4. **Phase 4**: Development (Test + Implementation)
    - Pass simplified/full decision to rules-engineer
+   - Run test-creator and rules-engineer in parallel (different folders)
+   - Report results
+   - **STOP - Wait for user to say "continue" or provide adjustments**
+
+5. **Phase 5**: Pre-Push Validation
    - Complete the phase
    - Report results
    - **STOP - Wait for user to say "continue" or provide adjustments**
 
-5. **Phase 5**: Branch Integration
+6. **Phase 6**: Validation
+   - Run validators
+   - Report results
+   - **STOP - Wait for user to say "continue" or provide adjustments**
+
+7. **Phase 7**: Local Testing & Fixes (Including Reference Verification)
    - Complete the phase
    - Report results
    - **STOP - Wait for user to say "continue" or provide adjustments**
 
-6. **Phase 6**: Pre-Push Validation
-   - Complete the phase
-   - Report results
-   - **STOP - Wait for user to say "continue" or provide adjustments**
-
-7. **Phase 7**: Parallel Validation (All Validators Simultaneously)
-   - Complete the phase
-   - Report results from all validators
-   - **STOP - Wait for user to say "continue" or provide adjustments**
-
-8. **Phase 8**: Local Testing & Fixes (Including Reference Verification)
-   - Complete the phase
-   - Report results
-   - **STOP - Wait for user to say "continue" or provide adjustments**
-
-9. **Phase 9**: Final Review & PR Ready
-   - Complete the phase
-   - Report final results
+8. **Phase 8**: Final Summary
+   - Update PR description
+   - Report final results (keep PR as draft)
    - **WORKFLOW COMPLETE**
 
 **CRITICAL RULES**:
 - Do NOT proceed to the next phase until user explicitly says to continue
 - After each phase, summarize what was accomplished
 - If user provides adjustments, incorporate them before continuing
-- All 9 phases are REQUIRED - pausing doesn't mean skipping
+- All 8 phases are REQUIRED - pausing doesn't mean skipping
 
 If any agent fails, report the failure but DO NOT attempt to fix it yourself. Wait for user instructions.


### PR DESCRIPTION
## Summary

Major improvements to the policyengine-claude plugin for v3.0.0:

### Workflow Simplification
- Reduced encode-policy from 9 phases to 8 (removed branch merging phase)
- All agents now work on the same branch (no worktrees needed)
- test-creator and rules-engineer run in parallel on same branch (different folders)
- Keep PR as draft - user decides when to mark ready

### Code Standards
- Remove `documentation` field from templates (use `reference` URL instead)
- Add "minimal comments" guidance to rules-engineer and code-style-skill
- Add all 7 skills to ci-fixer and tanf-program-reviewer for consistency

### File Organization
- Rename `document_collector.md` → `document-collector.md` (consistent naming)
- Add shared/ agents and workflow.md to marketplace.json
- All working .md files now saved to `sources/` folder
- Files kept for future reference (no longer deleted)

### Files Changed
- `.claude-plugin/marketplace.json` - Version bump, add agents
- `commands/encode-policy.md` - Simplified workflow
- `agents/country-models/rules-engineer.md` - Remove worktree, add comments guidance
- `agents/country-models/test-creator.md` - Remove worktree
- `agents/country-models/ci-fixer.md` - Use sources/, keep files
- `agents/country-models/document-collector.md` - Rename, use sources/
- `agents/country-models/issue-manager.md` - Use sources/
- `agents/country-models/tanf-program-reviewer.md` - Add skills
- `agents/country-models/documentation-enricher.md` - Remove documentation field
- `agents/shared/policyengine-standards.md` - Remove documentation field
- `skills/technical-patterns/policyengine-code-style-skill/SKILL.md` - Add minimal comments

## Test plan
- [ ] Run `/complete:encode-policy` with a simple TANF program
- [ ] Verify agents use `sources/` folder correctly
- [ ] Verify minimal comments guidance is followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)