### PR TITLE
Version 3.1.0: Upgrade country-models agents to Opus 4.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.ai/schemas/plugin-marketplace.json",
   "name": "policyengine-claude",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Complete PolicyEngine knowledge base - for users, analysts, and contributors across the entire PolicyEngine ecosystem",
   "owner": {
     "name": "PolicyEngine",
@@ -13,7 +13,7 @@
       "description": "Essential PolicyEngine knowledge for all users - understanding the platform, using the web app, and basic concepts",
       "source": "./",
       "category": "getting-started",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "keywords": ["beginner", "users", "guide", "basics"],
       "author": {
         "name": "PolicyEngine",
@@ -32,7 +32,7 @@
       "description": "Complete multi-agent workflow for implementing government benefit programs in PolicyEngine country packages",
       "source": "./",
       "category": "development",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "keywords": ["tax", "benefits", "microsimulation", "country-models", "rules", "testing"],
       "author": {
         "name": "PolicyEngine",
@@ -67,7 +67,7 @@
       "description": "API development - Flask endpoints, caching, services, and integration patterns",
       "source": "./",
       "category": "development",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "keywords": ["api", "flask", "backend", "rest", "endpoints"],
       "author": {
         "name": "PolicyEngine",
@@ -97,7 +97,7 @@
       "description": "React app development - components, routing, charts, and PolicyEngine-specific patterns",
       "source": "./",
       "category": "development",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "keywords": ["react", "frontend", "app", "ui", "components"],
       "author": {
         "name": "PolicyEngine",
@@ -127,7 +127,7 @@
       "description": "Policy analysis and research - impact studies, dashboards, notebooks, and visualizations",
       "source": "./",
       "category": "analysis",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "keywords": ["analysis", "research", "policy", "impact", "streamlit", "plotly", "notebooks"],
       "author": {
         "name": "PolicyEngine",
@@ -150,7 +150,7 @@
       "description": "Data analysis, survey enhancement, imputation, calibration, and microdata utilities",
       "source": "./",
       "category": "data",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "keywords": ["data", "microdata", "survey", "imputation", "calibration", "inequality", "poverty", "ml"],
       "author": {
         "name": "PolicyEngine",
@@ -174,7 +174,7 @@
       "description": "Complete PolicyEngine knowledge base - all agents, commands, and skills for users, analysts, and contributors",
       "source": "./",
       "category": "complete",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "keywords": ["complete", "all", "comprehensive"],
       "author": {
         "name": "PolicyEngine",

--- a/agents/country-models/ci-fixer.md
+++ b/agents/country-models/ci-fixer.md
@@ -2,7 +2,7 @@
 name: ci-fixer
 description: Creates PR, monitors CI, fixes issues iteratively until all tests pass
 tools: Bash, Read, Write, Edit, MultiEdit, Grep, Glob, TodoWrite
-model: sonnet
+model: opus
 color: orange
 ---
 

--- a/agents/country-models/cross-program-validator.md
+++ b/agents/country-models/cross-program-validator.md
@@ -2,7 +2,7 @@
 name: cross-program-validator
 description: Validates interactions between benefit programs to prevent integration issues
 tools: Read, Grep, Glob, TodoWrite
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/document-collector.md
+++ b/agents/country-models/document-collector.md
@@ -2,7 +2,7 @@
 name: document-collector
 description: Gathers authoritative documentation for government benefit program implementations
 tools: WebSearch, WebFetch, Read, Write, Grep, Glob, Bash
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/documentation-enricher.md
+++ b/agents/country-models/documentation-enricher.md
@@ -2,7 +2,7 @@
 name: documentation-enricher
 description: Automatically enriches code with examples, references, and calculation walkthroughs
 tools: Read, Edit, MultiEdit, Grep, Glob
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/edge-case-generator.md
+++ b/agents/country-models/edge-case-generator.md
@@ -2,7 +2,7 @@
 name: edge-case-generator
 description: Automatically generates comprehensive edge case tests for benefit programs
 tools: Read, Write, Grep, Glob, TodoWrite
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/implementation-validator.md
+++ b/agents/country-models/implementation-validator.md
@@ -2,7 +2,7 @@
 name: implementation-validator
 description: Comprehensive validator for PolicyEngine implementations - quality standards, domain patterns, naming conventions, and compliance
 tools: Read, Grep, Glob, TodoWrite, Bash
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/integration-agent.md
+++ b/agents/country-models/integration-agent.md
@@ -2,7 +2,7 @@
 name: integration-agent
 description: Merges parallel development branches and fixes basic integration issues
 tools: Bash, Read, Edit, MultiEdit, Grep, TodoWrite
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/issue-manager.md
+++ b/agents/country-models/issue-manager.md
@@ -2,7 +2,7 @@
 name: issue-manager
 description: Finds or creates GitHub issues for program implementations
 tools: Bash, Grep
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/naming-coordinator.md
+++ b/agents/country-models/naming-coordinator.md
@@ -2,7 +2,7 @@
 name: naming-coordinator
 description: Establishes variable naming conventions based on existing patterns
 tools: Grep, Glob, Read, Bash
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/parameter-architect.md
+++ b/agents/country-models/parameter-architect.md
@@ -2,7 +2,7 @@
 name: parameter-architect
 description: Designs comprehensive parameter structures with proper federal/state separation and zero hard-coding
 tools: Read, Write, Edit, MultiEdit, Grep, Glob, TodoWrite
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/performance-optimizer.md
+++ b/agents/country-models/performance-optimizer.md
@@ -2,7 +2,7 @@
 name: performance-optimizer
 description: Optimizes benefit calculations for performance and vectorization
 tools: Read, Edit, MultiEdit, Grep, Glob
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/pr-pusher.md
+++ b/agents/country-models/pr-pusher.md
@@ -2,7 +2,7 @@
 name: pr-pusher
 description: Ensures PRs are properly formatted with changelog, linting, and tests before pushing
 tools: Bash, Read, Write, Edit, Grep
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/rules-engineer.md
+++ b/agents/country-models/rules-engineer.md
@@ -2,7 +2,7 @@
 name: rules-engineer
 description: Implements government benefit program rules with zero hard-coded values and complete parameterization
 tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash, TodoWrite
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/tanf-program-reviewer.md
+++ b/agents/country-models/tanf-program-reviewer.md
@@ -2,7 +2,7 @@
 name: tanf-program-reviewer
 description: Reviews state TANF/benefit program implementations by learning from PA TANF and OH OWF examples, then validating code, regulations, tests, and documentation
 tools: Bash, Read, Grep, Glob, WebFetch, TodoWrite
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode

--- a/agents/country-models/test-creator.md
+++ b/agents/country-models/test-creator.md
@@ -2,7 +2,7 @@
 name: test-creator
 description: Creates comprehensive integration tests for government benefit programs ensuring realistic calculations
 tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash, TodoWrite
-model: sonnet
+model: opus
 ---
 
 ## Thinking Mode


### PR DESCRIPTION
## Summary
- Upgrade all 15 country-models agents from `model: sonnet` to `model: opus` (Opus 4.5)
- Bump version from 3.0.1 to 3.1.0 across all plugins in marketplace.json

## Changes
**Agents updated:**
- ci-fixer.md
- cross-program-validator.md
- document-collector.md
- documentation-enricher.md
- edge-case-generator.md
- implementation-validator.md
- integration-agent.md
- issue-manager.md
- naming-coordinator.md
- parameter-architect.md
- performance-optimizer.md
- pr-pusher.md
- rules-engineer.md
- tanf-program-reviewer.md
- test-creator.md

## Test plan
- [ ] Verify agents load correctly with new model setting
- [ ] Test a country-models agent invocation to confirm Opus 4.5 is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)