### PR TITLE
Version 3.1.1: Add Skill tool to agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.ai/schemas/plugin-marketplace.json",
   "name": "policyengine-claude",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Complete PolicyEngine knowledge base - for users, analysts, and contributors across the entire PolicyEngine ecosystem",
   "owner": {
     "name": "PolicyEngine",
@@ -13,7 +13,7 @@
       "description": "Essential PolicyEngine knowledge for all users - understanding the platform, using the web app, and basic concepts",
       "source": "./",
       "category": "getting-started",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "keywords": ["beginner", "users", "guide", "basics"],
       "author": {
         "name": "PolicyEngine",
@@ -32,7 +32,7 @@
       "description": "Complete multi-agent workflow for implementing government benefit programs in PolicyEngine country packages",
       "source": "./",
       "category": "development",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "keywords": ["tax", "benefits", "microsimulation", "country-models", "rules", "testing"],
       "author": {
         "name": "PolicyEngine",
@@ -67,7 +67,7 @@
       "description": "API development - Flask endpoints, caching, services, and integration patterns",
       "source": "./",
       "category": "development",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "keywords": ["api", "flask", "backend", "rest", "endpoints"],
       "author": {
         "name": "PolicyEngine",
@@ -97,7 +97,7 @@
       "description": "React app development - components, routing, charts, and PolicyEngine-specific patterns",
       "source": "./",
       "category": "development",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "keywords": ["react", "frontend", "app", "ui", "components"],
       "author": {
         "name": "PolicyEngine",
@@ -127,7 +127,7 @@
       "description": "Policy analysis and research - impact studies, dashboards, notebooks, and visualizations",
       "source": "./",
       "category": "analysis",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "keywords": ["analysis", "research", "policy", "impact", "streamlit", "plotly", "notebooks"],
       "author": {
         "name": "PolicyEngine",
@@ -150,7 +150,7 @@
       "description": "Data analysis, survey enhancement, imputation, calibration, and microdata utilities",
       "source": "./",
       "category": "data",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "keywords": ["data", "microdata", "survey", "imputation", "calibration", "inequality", "poverty", "ml"],
       "author": {
         "name": "PolicyEngine",
@@ -174,7 +174,7 @@
       "description": "Complete PolicyEngine knowledge base - all agents, commands, and skills for users, analysts, and contributors",
       "source": "./",
       "category": "complete",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "keywords": ["complete", "all", "comprehensive"],
       "author": {
         "name": "PolicyEngine",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2025-11-25
+
+### Fixed
+- Added `Skill` tool to 16 agents that reference skills but couldn't invoke them:
+  - **Country-models agents (15):** rules-engineer, tanf-program-reviewer, ci-fixer, test-creator, parameter-architect, implementation-validator, edge-case-generator, documentation-enricher, cross-program-validator, document-collector, performance-optimizer, naming-coordinator, integration-agent, issue-manager, pr-pusher
+  - **Other agents (1):** reference-validator
+- Agents can now dynamically load PolicyEngine skills (policyengine-implementation-patterns-skill, policyengine-parameter-patterns-skill, etc.) instead of just referencing them in documentation
+
+## [3.1.0] - 2025-11-25
+
+### Changed
+- Upgraded all 15 country-models agents from `model: sonnet` to `model: opus` (Opus 4.5)
+
+## [3.0.1] - 2025-11-25
+
+### Fixed
+- Fix duplicate agent registration by removing explicit `agents` arrays from country-models and complete plugins
+- Claude Code auto-discovers agents from the `agents/` directory, so listing them explicitly caused duplicates
+
+## [3.0.0] - 2025-11-25
+
+### Changed
+- Simplified encode-policy workflow from 9 phases to 8 (removed branch merging phase)
+- All agents now work on same branch (no git worktrees needed)
+- Keep PR as draft (don't auto-mark ready)
+- Working files now saved to `sources/` folder for reference
+- Renamed `document_collector.md` to `document-collector.md` for consistent naming
+- Added shared/ agents and workflow.md to marketplace.json
+
+### Added
+- Added all 7 technical pattern skills to ci-fixer and tanf-program-reviewer agents
+- Added minimal comments guidance to rules-engineer and code-style-skill
+
+### Removed
+- Removed `documentation` field from templates (use `reference` URL instead)
+
 ## [2.0.0] - 2025-10-18
 
 ### Added

--- a/agents/country-models/ci-fixer.md
+++ b/agents/country-models/ci-fixer.md
@@ -1,7 +1,7 @@
 ---
 name: ci-fixer
 description: Creates PR, monitors CI, fixes issues iteratively until all tests pass
-tools: Bash, Read, Write, Edit, MultiEdit, Grep, Glob, TodoWrite
+tools: Bash, Read, Write, Edit, MultiEdit, Grep, Glob, TodoWrite, Skill
 model: opus
 color: orange
 ---

--- a/agents/country-models/cross-program-validator.md
+++ b/agents/country-models/cross-program-validator.md
@@ -1,7 +1,7 @@
 ---
 name: cross-program-validator
 description: Validates interactions between benefit programs to prevent integration issues
-tools: Read, Grep, Glob, TodoWrite
+tools: Read, Grep, Glob, TodoWrite, Skill
 model: opus
 ---
 

--- a/agents/country-models/document-collector.md
+++ b/agents/country-models/document-collector.md
@@ -1,7 +1,7 @@
 ---
 name: document-collector
 description: Gathers authoritative documentation for government benefit program implementations
-tools: WebSearch, WebFetch, Read, Write, Grep, Glob, Bash
+tools: WebSearch, WebFetch, Read, Write, Grep, Glob, Bash, Skill
 model: opus
 ---
 

--- a/agents/country-models/documentation-enricher.md
+++ b/agents/country-models/documentation-enricher.md
@@ -1,7 +1,7 @@
 ---
 name: documentation-enricher
 description: Automatically enriches code with examples, references, and calculation walkthroughs
-tools: Read, Edit, MultiEdit, Grep, Glob
+tools: Read, Edit, MultiEdit, Grep, Glob, Skill
 model: opus
 ---
 

--- a/agents/country-models/edge-case-generator.md
+++ b/agents/country-models/edge-case-generator.md
@@ -1,7 +1,7 @@
 ---
 name: edge-case-generator
 description: Automatically generates comprehensive edge case tests for benefit programs
-tools: Read, Write, Grep, Glob, TodoWrite
+tools: Read, Write, Grep, Glob, TodoWrite, Skill
 model: opus
 ---
 

--- a/agents/country-models/implementation-validator.md
+++ b/agents/country-models/implementation-validator.md
@@ -1,7 +1,7 @@
 ---
 name: implementation-validator
 description: Comprehensive validator for PolicyEngine implementations - quality standards, domain patterns, naming conventions, and compliance
-tools: Read, Grep, Glob, TodoWrite, Bash
+tools: Read, Grep, Glob, TodoWrite, Bash, Skill
 model: opus
 ---
 

--- a/agents/country-models/integration-agent.md
+++ b/agents/country-models/integration-agent.md
@@ -1,7 +1,7 @@
 ---
 name: integration-agent
 description: Merges parallel development branches and fixes basic integration issues
-tools: Bash, Read, Edit, MultiEdit, Grep, TodoWrite
+tools: Bash, Read, Edit, MultiEdit, Grep, TodoWrite, Skill
 model: opus
 ---
 

--- a/agents/country-models/issue-manager.md
+++ b/agents/country-models/issue-manager.md
@@ -1,7 +1,7 @@
 ---
 name: issue-manager
 description: Finds or creates GitHub issues for program implementations
-tools: Bash, Grep
+tools: Bash, Grep, Skill
 model: opus
 ---
 

--- a/agents/country-models/naming-coordinator.md
+++ b/agents/country-models/naming-coordinator.md
@@ -1,7 +1,7 @@
 ---
 name: naming-coordinator
 description: Establishes variable naming conventions based on existing patterns
-tools: Grep, Glob, Read, Bash
+tools: Grep, Glob, Read, Bash, Skill
 model: opus
 ---
 

--- a/agents/country-models/parameter-architect.md
+++ b/agents/country-models/parameter-architect.md
@@ -1,7 +1,7 @@
 ---
 name: parameter-architect
 description: Designs comprehensive parameter structures with proper federal/state separation and zero hard-coding
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, TodoWrite
+tools: Read, Write, Edit, MultiEdit, Grep, Glob, TodoWrite, Skill
 model: opus
 ---
 

--- a/agents/country-models/performance-optimizer.md
+++ b/agents/country-models/performance-optimizer.md
@@ -1,7 +1,7 @@
 ---
 name: performance-optimizer
 description: Optimizes benefit calculations for performance and vectorization
-tools: Read, Edit, MultiEdit, Grep, Glob
+tools: Read, Edit, MultiEdit, Grep, Glob, Skill
 model: opus
 ---
 

--- a/agents/country-models/pr-pusher.md
+++ b/agents/country-models/pr-pusher.md
@@ -1,7 +1,7 @@
 ---
 name: pr-pusher
 description: Ensures PRs are properly formatted with changelog, linting, and tests before pushing
-tools: Bash, Read, Write, Edit, Grep
+tools: Bash, Read, Write, Edit, Grep, Skill
 model: opus
 ---
 

--- a/agents/country-models/rules-engineer.md
+++ b/agents/country-models/rules-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: rules-engineer
 description: Implements government benefit program rules with zero hard-coded values and complete parameterization
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash, TodoWrite
+tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash, TodoWrite, Skill
 model: opus
 ---
 

--- a/agents/country-models/tanf-program-reviewer.md
+++ b/agents/country-models/tanf-program-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: tanf-program-reviewer
 description: Reviews state TANF/benefit program implementations by learning from PA TANF and OH OWF examples, then validating code, regulations, tests, and documentation
-tools: Bash, Read, Grep, Glob, WebFetch, TodoWrite
+tools: Bash, Read, Grep, Glob, WebFetch, TodoWrite, Skill
 model: opus
 ---
 

--- a/agents/country-models/test-creator.md
+++ b/agents/country-models/test-creator.md
@@ -1,7 +1,7 @@
 ---
 name: test-creator
 description: Creates comprehensive integration tests for government benefit programs ensuring realistic calculations
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash, TodoWrite
+tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash, TodoWrite, Skill
 model: opus
 ---
 

--- a/agents/reference-validator.md
+++ b/agents/reference-validator.md
@@ -1,7 +1,7 @@
 ---
 name: reference-validator
 description: Validates that all parameters and variables have proper references that actually corroborate the values
-tools: Read, Grep, Glob, WebFetch, TodoWrite
+tools: Read, Grep, Glob, WebFetch, TodoWrite, Skill
 model: sonnet
 ---
 


### PR DESCRIPTION
## Summary

- Added `Skill` tool to 16 agents that reference skills but couldn't invoke them
- Agents can now dynamically load PolicyEngine skills instead of just referencing them in documentation

## Changes

**Country-models agents (15):**
- rules-engineer, tanf-program-reviewer, ci-fixer, test-creator, parameter-architect
- implementation-validator, edge-case-generator, documentation-enricher, cross-program-validator
- document-collector, performance-optimizer, naming-coordinator, integration-agent, issue-manager, pr-pusher

**Other agents (1):**
- reference-validator

## Also included

- Updated `marketplace.json` version to 3.1.1
- Updated `CHANGELOG.md` with accurate entries for 3.0.0, 3.0.1, 3.1.0, and 3.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)