### PR TITLE
Update skills to reference official docs

### DIFF
--- a/skills/analysis/policyengine-district-analysis-skill/SKILL.md
+++ b/skills/analysis/policyengine-district-analysis-skill/SKILL.md
@@ -12,6 +12,12 @@ description: |
 
 This skill enables district-level policy impact analysis using PolicyEngine microsimulation with weighted survey data.
 
+## Documentation References
+
+- **Microsimulation API**: https://policyengine.github.io/policyengine-us/usage/microsimulation.html
+- **Parameter Discovery**: https://policyengine.github.io/policyengine-us/usage/parameter-discovery.html
+- **Reform.from_dict()**: https://policyengine.github.io/policyengine-core/usage/reforms.html
+
 ## When to Use This Skill
 
 Use this skill when the user asks:
@@ -19,74 +25,37 @@ Use this skill when the user asks:
 - "Analyze [district code like NY-17 or CA-52]"
 - "How would [policy] affect [representative]'s constituents?"
 - "Compare [district] to national average for [policy]"
-- "District-level impact of [policy change]"
 
-## Step-by-Step Workflow
+## Workflow
 
-### Download District Data
+### 1. Load District Data
 
-Congressional district microdata is on HuggingFace. The URL parser in policyengine-core doesn't handle nested paths, so download manually:
+Congressional district microdata is on HuggingFace at `policyengine/policyengine-us-data/districts/`:
 
 ```python
-from huggingface_hub import hf_hub_download
-import os
+from policyengine_us import Microsimulation
 
-# Set token if needed
-os.environ['HUGGING_FACE_TOKEN'] = open(os.path.expanduser('~/.huggingface/token')).read().strip()
-
-# Download district file (e.g., NY-17)
 district_code = "NY-17"  # Format: {STATE}-{DISTRICT_NUMBER}
-file_path = hf_hub_download(
-    repo_id='policyengine/policyengine-us-data',
-    filename=f'districts/{district_code}.h5',
-    repo_type='model',
-    token=os.environ.get('HUGGING_FACE_TOKEN')
+district_sim = Microsimulation(
+    dataset=f'hf://policyengine/policyengine-us-data/districts/{district_code}.h5'
 )
 ```
 
-### Define the Policy Reform
+### 2. Find Parameter Paths
 
-#### Finding the Right Parameters
+Search policyengine-us to find the relevant parameters:
 
-Before defining a reform, find the exact parameter paths in the policyengine-us codebase:
-
-**1. Search the parameters directory:**
 ```bash
-# Find parameters related to your policy
 grep -r "salt" policyengine_us/parameters/gov/irs/ --include="*.yaml"
-grep -r "child_tax_credit\|ctc" policyengine_us/parameters/gov/irs/credits/ --include="*.yaml"
-grep -r "eitc" policyengine_us/parameters/gov/irs/credits/ --include="*.yaml"
-```
-
-**2. Navigate the parameter tree structure:**
-- Federal tax: `gov.irs.deductions`, `gov.irs.credits`, `gov.irs.income`
-- State taxes: `gov.states.{state_code}.tax`
-- Benefits: `gov.hhs`, `gov.usda`, `gov.ed`
-
-**3. Read the YAML file to understand structure:**
-```bash
-# Example: Check SALT cap parameter structure
 cat policyengine_us/parameters/gov/irs/deductions/itemized/salt_and_real_estate/cap.yaml
 ```
 
-Parameter YAML files show:
-- The parameter path (matches directory structure)
-- Filing status breakdowns (SINGLE, JOINT, SEPARATE, HEAD_OF_HOUSEHOLD, SURVIVING_SPOUSE)
-- Date ranges for values
-- Units and descriptions
-
-#### Creating the Reform
-
-Use `Reform.from_dict()` with the discovered parameter paths:
+### 3. Define Reform
 
 ```python
 from policyengine_core.reforms import Reform
 
-# Example: SALT cap change (after finding paths via grep/exploration)
 reform = Reform.from_dict({
-    'gov.irs.deductions.itemized.salt_and_real_estate.cap.SINGLE': {
-        '2026-01-01.2100-12-31': 10000  # New cap amount
-    },
     'gov.irs.deductions.itemized.salt_and_real_estate.cap.JOINT': {
         '2026-01-01.2100-12-31': 10000
     },
@@ -94,130 +63,50 @@ reform = Reform.from_dict({
 }, 'policyengine_us')
 ```
 
-**Key patterns:**
-- Date format: `'YYYY-MM-DD.YYYY-MM-DD'` for start and end dates
-- Bracket parameters use `[index]` syntax: `gov.irs.credits.ctc.amount.base[0].amount`
-- Always check if parameter varies by filing status and include all variants
-
-### Run District and National Simulations
+### 4. Run Comparison
 
 ```python
 from policyengine_us import Microsimulation
 import numpy as np
 
-# District simulation
-district_baseline = Microsimulation(dataset=file_path)
-district_reformed = Microsimulation(dataset=file_path, reform=reform)
+# District
+district_baseline = Microsimulation(dataset=f'hf://policyengine/policyengine-us-data/districts/{district_code}.h5')
+district_reformed = Microsimulation(dataset=f'hf://policyengine/policyengine-us-data/districts/{district_code}.h5', reform=reform)
 
-# National simulation for comparison
-national_baseline = Microsimulation()  # Uses default enhanced_cps_2024.h5
+# National
+national_baseline = Microsimulation()
 national_reformed = Microsimulation(reform=reform)
 
-period = 2026  # Or relevant year
+# Calculate at person level for population shares
+def get_loser_share(baseline, reformed, period=2026):
+    baseline_inc = baseline.calc('household_net_income', period=period, map_to='person')
+    reformed_inc = reformed.calc('household_net_income', period=period, map_to='person')
+    change = reformed_inc - baseline_inc
+    return change.weights[change.values < 0].sum() / change.weights.sum()
+
+district_loser_share = get_loser_share(district_baseline, district_reformed)
+national_loser_share = get_loser_share(national_baseline, national_reformed)
+
+print(f"District: {district_loser_share:.1%} lose")
+print(f"National: {national_loser_share:.1%} lose")
+print(f"Relative impact: {district_loser_share/national_loser_share:.1f}x")
 ```
 
-### Calculate Winners/Losers
+### 5. Present Results
 
-```python
-def analyze_impact(baseline_sim, reform_sim, period=2026):
-    """Calculate share who win, lose, and amounts."""
-
-    # Person-level for population shares
-    baseline = baseline_sim.calc('household_net_income', period=period, map_to='person')
-    reformed = reform_sim.calc('household_net_income', period=period, map_to='person')
-    change = reformed - baseline
-
-    total_weight = change.weights.sum()
-
-    results = {
-        'total_population': total_weight,
-        'loser_share': change.weights[change.values < 0].sum() / total_weight,
-        'winner_share': change.weights[change.values > 0].sum() / total_weight,
-        'unchanged_share': change.weights[change.values == 0].sum() / total_weight,
-    }
-
-    # Average loss among losers
-    if results['loser_share'] > 0:
-        loser_vals = change.values[change.values < 0]
-        loser_weights = change.weights[change.values < 0]
-        results['avg_loss'] = -np.average(loser_vals, weights=loser_weights)
-
-    # Average gain among winners
-    if results['winner_share'] > 0:
-        winner_vals = change.values[change.values > 0]
-        winner_weights = change.weights[change.values > 0]
-        results['avg_gain'] = np.average(winner_vals, weights=winner_weights)
-
-    # Overall impact
-    results['avg_impact'] = np.average(change.values, weights=change.weights)
-    results['total_impact'] = (change.values * change.weights).sum()
-
-    return results
-
-# Run analysis
-district_results = analyze_impact(district_baseline, district_reformed, period)
-national_results = analyze_impact(national_baseline, national_reformed, period)
-```
-
-### Present Results
-
-Format results as a comparison table:
-
-```
+```markdown
 ## [Policy] Impact: [District] vs National
 
 | Metric | [District] | National | Difference |
 |--------|------------|----------|------------|
-| Share of people losing | X.X% | Y.Y% | +Z.Z pp |
-| Average loss among losers | $X,XXX | $Y,YYY | +$Z,ZZZ |
-| Average impact per household | -$XXX | -$YYY | -$ZZZ |
+| Share losing | X.X% | Y.Y% | +Z.Z pp |
+| Average loss | $X,XXX | $Y,YYY | +$Z,ZZZ |
 
-### Key Takeaway
-[District] residents are [X]x more/less affected than the national average because...
+**Key takeaway**: [District] residents are [X]x more affected because...
 ```
 
-## Current Law Context (2026)
+## Weight Sanity Checks
 
-**SALT Cap under OBBBA (signed July 2025):**
-- 2025: $40,000 ($20k MFS)
-- 2026: $40,400 ($20.2k MFS)
-- 2027-2029: Annual 1% increases
-- 2030+: Reverts to $10,000
-- Phaseout: Begins at $500k AGI, 30% rate, floors at $10k
-
-**Child Tax Credit:**
-- 2025: $2,000/child (TCJA rates extended)
-- Refundable portion varies by year
-
-## Common Analysis Requests
-
-1. **"What share would lose from cutting SALT to $10k?"**
-   - Compare current law ($40k cap) to $10k cap
-   - Report loser_share and avg_loss
-
-2. **"How does [district] compare to national?"**
-   - Run both district and national simulations
-   - Report relative impact (district / national ratios)
-
-3. **"Impact of [CTC/EITC/etc.] expansion in [district]"**
-   - Define reform for the relevant credit
-   - Report winner_share and avg_gain
-
-## Troubleshooting
-
-**HuggingFace authentication:**
-```bash
-# If prompted for token, set environment variable
-export HUGGING_FACE_TOKEN=$(cat ~/.huggingface/token)
-```
-
-**Memory issues with national simulation:**
-```python
-sim = Microsimulation()
-sim.subsample(10000)  # Use 10k households for testing
-```
-
-**Verify weights make sense:**
-- National: ~145-150M households
-- State: Varies (CA ~14M, WY ~250k)
-- District: ~175-400k households typically
+- National: ~130M households, ~330M people
+- District: ~200-400k households typically
+- State: varies (CA ~14M, WY ~250k)

--- a/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
@@ -7,6 +7,13 @@ description: Run population-level policy simulations using PolicyEngine-US/UK Mi
 
 This skill covers running **population-level** simulations using the `Microsimulation` class with weighted survey data. This is different from household-level `Simulation` which analyzes specific families.
 
+## Documentation References
+
+For comprehensive documentation, see:
+- **Microsimulation API**: https://policyengine.github.io/policyengine-us/usage/microsimulation.html
+- **Parameter Discovery**: https://policyengine.github.io/policyengine-us/usage/parameter-discovery.html
+- **Reform.from_dict()**: https://policyengine.github.io/policyengine-core/usage/reforms.html
+
 ## When to Use Microsimulation vs Simulation
 
 | Use Case | Class | Data Source |
@@ -16,12 +23,11 @@ This skill covers running **population-level** simulations using the `Microsimul
 | "How much would policy X cost nationwide?" | `Microsimulation` | Survey microdata |
 | "Compare impacts in NY-17 vs national average" | `Microsimulation` | District/national microdata |
 
-## Quick Start: National Analysis
+## Quick Start
 
 ```python
 from policyengine_us import Microsimulation
 from policyengine_core.reforms import Reform
-import numpy as np
 
 # Load national enhanced CPS (default dataset)
 baseline = Microsimulation()
@@ -38,242 +44,98 @@ reformed = Microsimulation(reform=reform)
 # Calculate impacts (calc() returns weighted MicroSeries)
 baseline_income = baseline.calc('household_net_income', period=2026)
 reformed_income = reformed.calc('household_net_income', period=2026)
-income_change = reformed_income - baseline_income
+change = reformed_income - baseline_income
 
 # Weighted statistics
-print(f"Average impact: ${income_change.mean():,.0f}")
-print(f"Total cost: ${-income_change.sum()/1e9:,.1f} billion")
+print(f"Average impact: ${change.mean():,.0f}")
+print(f"Total cost: ${-change.sum()/1e9:,.1f} billion")
 
-# Winners/losers analysis
-total_weight = income_change.weights.sum()
-loser_share = income_change.weights[income_change.values < 0].sum() / total_weight
+# Winners/losers
+loser_share = change.weights[change.values < 0].sum() / change.weights.sum()
 print(f"Share losing: {loser_share*100:.1f}%")
 ```
 
-## Available Microdata Datasets
+## Available Datasets (HuggingFace)
 
-### Hugging Face Repository Structure
-
-All datasets are in `policyengine/policyengine-us-data` on Hugging Face:
+All datasets are in `policyengine/policyengine-us-data`:
 
 ```
 hf://policyengine/policyengine-us-data/
 ├── enhanced_cps_2024.h5          # National (DEFAULT)
 ├── states/
-│   ├── NY.h5                     # New York state
-│   ├── CA.h5                     # California
-│   └── ...                       # All 50 states + DC
+│   ├── NY.h5, CA.h5, ...         # All 50 states + DC
 └── districts/
-    ├── NY-17.h5                  # Congressional districts
-    ├── CA-52.h5
-    └── ...                       # All 435+ districts
+    ├── NY-17.h5, CA-52.h5, ...   # All 435+ congressional districts
 ```
 
-### Loading Different Geographies
-
 ```python
-# National (default - no dataset argument needed)
+# National (default)
 sim = Microsimulation()
 
 # State-level
 sim = Microsimulation(dataset='hf://policyengine/policyengine-us-data/states/NY.h5')
 
-# Congressional district level
+# Congressional district
 sim = Microsimulation(dataset='hf://policyengine/policyengine-us-data/districts/NY-17.h5')
 ```
 
-**Note:** District files use state abbreviation + district number (e.g., `NY-17`, `CA-52`, `TX-03`).
-
-### HuggingFace Authentication
-
-For private datasets, set the environment variable:
-```bash
-export HUGGING_FACE_TOKEN=$(cat ~/.huggingface/token)
-```
-
-Or download manually:
-```python
-from huggingface_hub import hf_hub_download
-
-file_path = hf_hub_download(
-    repo_id='policyengine/policyengine-us-data',
-    filename='districts/NY-17.h5',
-    repo_type='model',
-    token=os.environ.get('HUGGING_FACE_TOKEN')
-)
-sim = Microsimulation(dataset=file_path)
-```
-
-## Core Calculation Methods
+## Key Methods
 
 ### calc() - Returns Weighted MicroSeries
 
 ```python
-# calc() returns MicroSeries with embedded weights
 income = sim.calc('household_net_income', period=2026)
-
-# Automatic weighted operations
-mean_income = income.mean()      # Weighted mean
-total_income = income.sum()      # Weighted sum
-median_income = income.median()  # Weighted median
-
-# Access raw values and weights
-values = income.values           # numpy array
-weights = income.weights         # numpy array
-
-# Manual weighted calculations
-weighted_avg = np.average(values, weights=weights)
+income.mean()      # Weighted mean
+income.sum()       # Weighted sum
+income.median()    # Weighted median
+income.values      # Raw numpy array
+income.weights     # Weight array
 ```
 
-### calculate() - Returns Raw Values
+### map_to - Entity Mapping
 
 ```python
-# calculate() returns raw numpy array (no weights)
-income_values = sim.calculate('household_net_income', period=2026)
-weights = sim.calculate('household_weight', period=2026)
-
-# Manual weighted mean
-weighted_mean = np.average(income_values, weights=weights)
-```
-
-### Entity Mapping with map_to
-
-```python
-# Calculate at person level, mapped from household
+# Map household variable to person level (for person-weighted stats)
 person_income = sim.calc('household_net_income', period=2026, map_to='person')
-
-# Calculate at household level (default for household variables)
-hh_income = sim.calc('household_net_income', period=2026, map_to='household')
 ```
 
-## Common Analysis Patterns
+## Finding Parameter Paths
 
-### Pattern 1: Winners/Losers Analysis
-
-```python
-from policyengine_us import Microsimulation
-from policyengine_core.reforms import Reform
-import numpy as np
-
-def analyze_winners_losers(baseline_sim, reform_sim, period=2026):
-    """Calculate share of population that wins, loses, or is unchanged."""
-
-    # Person-level analysis for population shares
-    baseline = baseline_sim.calc('household_net_income', period=period, map_to='person')
-    reformed = reform_sim.calc('household_net_income', period=period, map_to='person')
-    change = reformed - baseline
-
-    total_weight = change.weights.sum()
-
-    results = {
-        'total_population': total_weight,
-        'loser_share': change.weights[change.values < 0].sum() / total_weight,
-        'winner_share': change.weights[change.values > 0].sum() / total_weight,
-        'unchanged_share': change.weights[change.values == 0].sum() / total_weight,
-    }
-
-    # Among losers
-    if results['loser_share'] > 0:
-        loser_vals = change.values[change.values < 0]
-        loser_weights = change.weights[change.values < 0]
-        results['avg_loss'] = -np.average(loser_vals, weights=loser_weights)
-
-    return results
-```
-
-### Pattern 2: Geographic Comparison
-
-```python
-def compare_district_to_national(district_code, reform, period=2026):
-    """Compare policy impact in a district vs national average."""
-
-    # National baseline and reform
-    national_baseline = Microsimulation()
-    national_reformed = Microsimulation(reform=reform)
-
-    # District baseline and reform
-    district_path = f'hf://policyengine/policyengine-us-data/districts/{district_code}.h5'
-    # Note: May need to download manually if HF URL parsing doesn't work
-    district_baseline = Microsimulation(dataset=district_path)
-    district_reformed = Microsimulation(dataset=district_path, reform=reform)
-
-    national_results = analyze_winners_losers(national_baseline, national_reformed, period)
-    district_results = analyze_winners_losers(district_baseline, district_reformed, period)
-
-    return {
-        'national': national_results,
-        'district': district_results,
-        'relative_impact': district_results['loser_share'] / national_results['loser_share']
-    }
-```
-
-### Pattern 3: Finding Parameter Paths
-
-To create a reform, first find the exact parameter paths:
+To create a reform, find the parameter paths in policyengine-us:
 
 ```bash
-# Search policyengine-us parameters for relevant policy
+# Search parameters directory
 grep -r "salt" policyengine_us/parameters/gov/irs/ --include="*.yaml"
-grep -r "child_tax_credit\|ctc" policyengine_us/parameters/gov/irs/credits/ --include="*.yaml"
 
-# Read the YAML to understand structure
+# Read YAML to understand structure
 cat policyengine_us/parameters/gov/irs/deductions/itemized/salt_and_real_estate/cap.yaml
 ```
 
 **Parameter tree structure:**
 - Federal tax: `gov.irs.deductions`, `gov.irs.credits`, `gov.irs.income`
 - State taxes: `gov.states.{state_code}.tax`
-- Benefits: `gov.hhs` (Medicaid, TANF), `gov.usda` (SNAP), `gov.ed` (Pell)
+- Benefits: `gov.hhs`, `gov.usda`, `gov.ed`
 
 **Key patterns:**
-- Filing status variants: Many tax parameters have SINGLE, JOINT, SEPARATE, HEAD_OF_HOUSEHOLD, SURVIVING_SPOUSE
-- Bracket parameters: Use `[index]` syntax, e.g., `gov.irs.credits.ctc.amount.base[0].amount`
+- Filing status variants: SINGLE, JOINT, SEPARATE, HEAD_OF_HOUSEHOLD, SURVIVING_SPOUSE
+- Bracket parameters: `[index]` syntax, e.g., `gov.irs.credits.ctc.amount.base[0].amount`
 - Date ranges: `'YYYY-MM-DD.YYYY-MM-DD'` format
 
+## Weight Sanity Checks
+
 ```python
-# After finding paths via grep, create reform
-reform = Reform.from_dict({
-    'gov.irs.deductions.itemized.salt_and_real_estate.cap.JOINT': {
-        '2026-01-01.2100-12-31': 10000
-    },
-    # Include all filing statuses found in the YAML
-}, 'policyengine_us')
+# National: ~130M households, ~330M people
+weights = sim.calc('household_weight')
+print(f"Total households: {weights.sum()/1e6:.0f}M")
+
+# District: ~200-400k households
+# State: varies (CA ~14M, WY ~250k)
 ```
 
-## Key Variables for Policy Analysis
-
-### Income & Taxes
-- `household_net_income` - After-tax income
-- `income_tax` - Federal income tax
-- `payroll_tax` - Social Security and Medicare taxes
-- `state_income_tax` - State income tax
-- `adjusted_gross_income` - AGI for tax calculations
-
-### Demographics
-- `household_weight` - Survey weight
-- `state_fips` - State FIPS code
-- `congressional_district_geoid` - Congressional district code
-- `age` - Person age
-- `employment_income` - Wages and salaries
-
-## Troubleshooting
-
-### Weight Sanity Checks
+## Performance Tips
 
 ```python
-# National dataset should have ~150M households
-weights = sim.calculate('household_weight', period=2026)
-print(f"Total households: {weights.sum()/1e6:.1f}M")  # Should be ~145-150M
-
-# District should have ~200-400k households
-# State should have millions (varies by state)
-```
-
-### Memory Issues
-
-For national simulations, memory usage can be high. Use subsampling for testing:
-
-```python
+# Subsample for faster development
 sim = Microsimulation()
-sim.subsample(10000)  # Use 10k households for testing
+sim.subsample(10_000)  # Use 10k households
 ```


### PR DESCRIPTION
## Summary
Skills now link to the published documentation instead of duplicating content:
- Microsimulation API: https://policyengine.github.io/policyengine-us/usage/microsimulation.html
- Parameter Discovery: https://policyengine.github.io/policyengine-us/usage/parameter-discovery.html
- Reform.from_dict(): https://policyengine.github.io/policyengine-core/usage/reforms.html

Reduced skill file sizes by ~75% while keeping essential quick-reference patterns.

## Test plan
- [ ] Verify skill still triggers on natural language queries
- [ ] Confirm doc links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)