### PR TITLE
Make district-analysis and microsimulation skills user-invocable

### DIFF
--- a/skills/analysis/policyengine-district-analysis-skill/SKILL.md
+++ b/skills/analysis/policyengine-district-analysis-skill/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: policyengine-district-analysis
+user_invocable: true
 description: |
   Analyzes policy impacts at the congressional district level using PolicyEngine microsimulation.
   Use when analyzing a specific congressional district, asking about policy impacts in a representative's district,

--- a/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: policyengine-microsimulation
+user_invocable: true
 description: Run population-level policy simulations using PolicyEngine-US/UK Microsimulation with weighted microdata - national, state, and congressional district level analysis
 ---
 


### PR DESCRIPTION
## Summary
- Adds `user_invocable: true` to district-analysis and microsimulation skills
- Allows users to explicitly invoke with `/policyengine-district-analysis` or `/policyengine-microsimulation`

This helps when Claude doesn't automatically recognize to use these skills for district/microsim queries.

## Test plan
- [ ] Run `/policyengine-district-analysis` in Claude Code
- [ ] Run `/policyengine-microsimulation` in Claude Code
- [ ] Verify skills appear in `/skills` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)