### PR TITLE
Strengthen skill descriptions for auto-triggering

### DIFF
--- a/skills/analysis/policyengine-district-analysis-skill/SKILL.md
+++ b/skills/analysis/policyengine-district-analysis-skill/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: policyengine-district-analysis
-user_invocable: true
 description: |
-  Analyzes policy impacts at the congressional district level using PolicyEngine microsimulation.
-  Use when analyzing a specific congressional district, asking about policy impacts in a representative's district,
-  questions like "analyze NY-17", "what share of people in Mike Lawler's district would lose from...",
-  "how would [policy] affect [representative]'s constituents", "compare [district] to national average",
-  or any district-level policy simulation questions.
+  ALWAYS USE THIS SKILL when analyzing policy impacts for congressional districts, representatives' constituents, or geographic areas.
+  Triggers: "Mike Lawler", "NY-17", "district", "congressional", "representative's district", "constituents",
+  "share of people who would lose/gain", "SALT cap", policy impact analysis, microsimulation questions.
+  This skill provides the EXACT code pattern - do NOT explore the codebase, just follow the template.
 ---
 
 # Congressional District Policy Analysis

--- a/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: policyengine-microsimulation
-user_invocable: true
-description: Run population-level policy simulations using PolicyEngine-US/UK Microsimulation with weighted microdata - national, state, and congressional district level analysis
+description: |
+  ALWAYS USE THIS SKILL for PolicyEngine microsimulation, population-level analysis, winners/losers calculations.
+  Triggers: "microsimulation", "share who would lose/gain", "policy impact", "national average", weighted analysis.
+  This skill provides the EXACT code pattern - do NOT explore the codebase, just follow the template.
 ---
 
 # PolicyEngine Microsimulation


### PR DESCRIPTION
## Summary
- Updates district-analysis and microsimulation skill descriptions to be more assertive
- Adds explicit trigger keywords ("Mike Lawler", "NY-17", "SALT cap", etc.)
- Tells Claude NOT to explore codebase but to follow the template

The goal is for Claude to automatically invoke these skills based on query context rather than requiring explicit `/skill` invocation.

## Test plan
- [ ] Ask "calculate share of people in Mike Lawler's district who would lose from cutting SALT cap to 10k"
- [ ] Verify Claude uses the skill template instead of Explore agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)