### PR TITLE
Generalize district-analysis skill description

### DIFF
--- a/skills/analysis/policyengine-district-analysis-skill/SKILL.md
+++ b/skills/analysis/policyengine-district-analysis-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: policyengine-district-analysis
-description: Congressional district microsimulation - HuggingFace district datasets, Mike Lawler NY-17, share who would lose/gain from policy changes like SALT cap
+description: PolicyEngine analysis for congressional districts and representatives' constituents - calculates share of people who would lose/gain from policy changes using HuggingFace district-level microdata
 ---
 
 # Congressional District Policy Analysis


### PR DESCRIPTION
Remove specific examples and use general language that matches user queries.