### PR TITLE
Add cross-references between skills

### DIFF
--- a/skills/domain-knowledge/policyengine-us-skill/SKILL.md
+++ b/skills/domain-knowledge/policyengine-us-skill/SKILL.md
@@ -118,10 +118,12 @@ The household ID represents a situation dictionary. To replicate in Python, you'
 ### When to Use This Skill
 
 - Creating household situations for tax/benefit calculations
-- Running microsimulations with PolicyEngine-US
-- Analyzing policy reforms and their impacts
+- Understanding variables, parameters, and policy reforms
 - Building tools that use PolicyEngine-US (calculators, analysis notebooks)
 - Debugging PolicyEngine-US calculations
+
+**For microsimulation/population analysis**, see the `policyengine-microsimulation` skill.
+**For congressional district analysis**, see the `policyengine-district-analysis` skill.
 
 ## For Contributors 💻
 

--- a/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
@@ -60,9 +60,11 @@ sim = Microsimulation()
 # State-level
 sim = Microsimulation(dataset='hf://policyengine/policyengine-us-data/states/NY.h5')
 
-# Congressional district
+# Congressional district - SEE policyengine-district-analysis skill for full examples
 sim = Microsimulation(dataset='hf://policyengine/policyengine-us-data/districts/NY-17.h5')
 ```
+
+**For congressional district analysis** (representative's constituents, district-level impacts), use the `policyengine-district-analysis` skill which has complete examples.
 
 ## Key MicroSeries Methods
 


### PR DESCRIPTION
## Summary
- policyengine-us skill points to microsimulation and district-analysis skills
- policyengine-microsimulation skill points to district-analysis for district work
- Generalize district-analysis description (remove specific examples)

This helps Claude navigate to the right skill when a user asks about districts - even if it loads policyengine-us first, it will see the pointer to district-analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)