### PR TITLE
Add policyengine-research-lookup-skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude.ai/schemas/plugin-marketplace.json",
   "name": "policyengine-claude",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Complete PolicyEngine knowledge base - for users, analysts, and contributors across the entire PolicyEngine ecosystem",
   "owner": {
     "name": "PolicyEngine",
@@ -13,7 +13,7 @@
       "description": "Essential PolicyEngine knowledge for all users - understanding the platform, using the web app, and basic concepts",
       "source": "./",
       "category": "getting-started",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "keywords": ["beginner", "users", "guide", "basics"],
       "author": {
         "name": "PolicyEngine",
@@ -33,7 +33,7 @@
       "description": "Complete multi-agent workflow for implementing government benefit programs in PolicyEngine country packages",
       "source": "./",
       "category": "development",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "keywords": ["tax", "benefits", "microsimulation", "country-models", "rules", "testing"],
       "author": {
         "name": "PolicyEngine",
@@ -90,7 +90,7 @@
       "description": "API development - Flask endpoints, caching, services, and integration patterns",
       "source": "./",
       "category": "development",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "keywords": ["api", "flask", "backend", "rest", "endpoints"],
       "author": {
         "name": "PolicyEngine",
@@ -120,7 +120,7 @@
       "description": "React app development - components, routing, charts, and PolicyEngine-specific patterns",
       "source": "./",
       "category": "development",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "keywords": ["react", "frontend", "app", "ui", "components"],
       "author": {
         "name": "PolicyEngine",
@@ -150,7 +150,7 @@
       "description": "Policy analysis and research - impact studies, dashboards, notebooks, and visualizations",
       "source": "./",
       "category": "analysis",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "keywords": ["analysis", "research", "policy", "impact", "streamlit", "plotly", "notebooks"],
       "author": {
         "name": "PolicyEngine",
@@ -168,7 +168,8 @@
         "./skills/analysis/policyengine-district-analysis-skill",
         "./skills/data-science/microdf-skill",
         "./skills/documentation/policyengine-design-skill",
-        "./skills/documentation/policyengine-writing-skill"
+        "./skills/documentation/policyengine-writing-skill",
+        "./skills/documentation/policyengine-research-lookup-skill"
       ]
     },
     {
@@ -176,7 +177,7 @@
       "description": "Data analysis, survey enhancement, imputation, calibration, and microdata utilities",
       "source": "./",
       "category": "data",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "keywords": ["data", "microdata", "survey", "imputation", "calibration", "inequality", "poverty", "ml"],
       "author": {
         "name": "PolicyEngine",
@@ -203,7 +204,7 @@
       "description": "Complete PolicyEngine knowledge base - all agents, commands, and skills for users, analysts, and contributors",
       "source": "./",
       "category": "complete",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "keywords": ["complete", "all", "comprehensive"],
       "author": {
         "name": "PolicyEngine",
@@ -273,7 +274,8 @@
         "./skills/data-science/policyengine-us-data-skill",
         "./skills/documentation/policyengine-design-skill",
         "./skills/documentation/policyengine-standards-skill",
-        "./skills/documentation/policyengine-writing-skill"
+        "./skills/documentation/policyengine-writing-skill",
+        "./skills/documentation/policyengine-research-lookup-skill"
       ]
     }
   ]

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,6 +1,5 @@
-- bump: patch
+- bump: minor
   changes:
     added:
-      - Document bracket parameter pattern for handling negative values (-.inf vs 0 thresholds) in parameter patterns skill
-    changed:
-      - Add critical warning against mixing adds/subtracts with custom formulas in implementation patterns skill
+      - Add policyengine-research-lookup-skill for finding blog posts, proof points, and published analyses
+      - Register research-lookup skill in analysis-tools and complete plugins

--- a/skills/README.md
+++ b/skills/README.md
@@ -39,6 +39,7 @@ skills/
 │
 ├── documentation/          # Writing, standards, and guides
 │   ├── policyengine-design-skill/
+│   ├── policyengine-research-lookup-skill/
 │   ├── policyengine-standards-skill/
 │   ├── policyengine-user-guide-skill/
 │   └── policyengine-writing-skill/
@@ -109,6 +110,7 @@ Standards for writing, design, and user guidance.
 | Skill | Description | Application |
 |-------|-------------|-------------|
 | **policyengine-design-skill** | Visual identity | Colors, fonts, logos, branding for all PolicyEngine materials |
+| **policyengine-research-lookup-skill** | Finding existing research | Blog posts, proof points, published analyses for talks and pitches |
 | **policyengine-standards-skill** | Coding standards | Formatters, CI requirements, development best practices |
 | **policyengine-user-guide-skill** | Using PolicyEngine web apps | Analyzing tax and benefit policy impacts |
 | **policyengine-writing-skill** | Writing style guide | Blog posts, documentation, PR descriptions, research reports |

--- a/skills/documentation/policyengine-research-lookup-skill/SKILL.md
+++ b/skills/documentation/policyengine-research-lookup-skill/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: policyengine-research-lookup
+description: Find and reference PolicyEngine blog posts, research articles, and published analyses for evidence and proof points
+---
+
+# PolicyEngine Research Lookup
+
+Use this skill to find existing PolicyEngine research, blog posts, and published analyses that can serve as evidence, proof points, or references.
+
+## For Users 👥
+
+### What is PolicyEngine Research?
+
+PolicyEngine publishes research through:
+- **Blog posts**: Policy analyses, model updates, methodology explanations
+- **Research reports**: In-depth studies for partners and stakeholders
+- **Dashboards**: Interactive tools for specific policy questions
+
+### Key Research Highlights
+
+**Government adoption:**
+- Our CTO spent 6 months at **10 Downing Street** adapting PolicyEngine for UK government use (see `policyengine-10-downing-street.md`)
+
+**State coverage:**
+- US model covers federal + state taxes for all 50 states
+- State-specific posts: California, New York, Kansas, Montana, Oregon, Utah, Washington, Minnesota
+
+**UK coverage:**
+- Full UK tax-benefit system
+- Autumn Budget analyses, manifesto costing
+
+## For Analysts 📊
+
+### Finding Blog Posts
+
+**Location in codebase:**
+```
+~/policyengine-app-v2/app/src/data/posts/articles/
+```
+
+**Search for topics:**
+```bash
+# Find posts mentioning a topic
+find ~/policyengine-app-v2/app/src/data/posts/articles/ -name "*.md" | \
+  xargs grep -l -i "topic" 2>/dev/null
+
+# List all posts
+ls ~/policyengine-app-v2/app/src/data/posts/articles/
+```
+
+**Post metadata is in:**
+```
+~/policyengine-app-v2/app/src/data/posts/posts.json
+```
+
+### Key Posts to Reference
+
+| Topic | File | Use Case |
+|-------|------|----------|
+| Government adoption | `policyengine-10-downing-street.md` | Credibility, state capacity |
+| State tax models | `state-tax-model-beta.md` | US state coverage |
+| Machine learning | Various | Accuracy, methodology |
+| Budget analyses | `autumn-budget-*.md` | UK policy coverage |
+| US tax proposals | `*-tax-*.md`, `*-ctc-*.md` | Federal policy coverage |
+
+### Post Structure
+
+Each post is markdown with YAML frontmatter:
+```yaml
+---
+title: "Post Title"
+date: "2025-01-15"
+authors:
+  - name: Author Name
+tags:
+  - us
+  - federal
+---
+```
+
+## For Contributors 💻
+
+### When to Use This Skill
+
+- Preparing talks, pitches, or presentations about PolicyEngine
+- Finding proof points for PolicyEngine's credibility
+- Referencing specific analyses in conversations
+- Looking up methodology explanations
+- Finding state or country-specific coverage
+
+### Common Lookups
+
+**"What's our strongest credibility proof point?"**
+→ 10 Downing Street blog post: CTO spent 6 months adapting PolicyEngine for UK government
+
+**"Do we cover [state] taxes?"**
+→ Search for state name in posts directory; also check policyengine-us-skill
+
+**"What did we write about [policy]?"**
+→ Search posts directory for policy name or related terms
+
+**"Where can I find our methodology for [X]?"**
+→ Search for technical posts; check also policyengine-core-skill
+
+### Adding New Research References
+
+When PolicyEngine publishes significant new research:
+1. Note the filename in this skill if it's a key proof point
+2. Update the "Key Posts to Reference" table above
+3. Consider if it warrants mention in related skills (e.g., country skills)
+
+## Resources
+
+- Blog posts: `~/policyengine-app-v2/app/src/data/posts/articles/`
+- Post index: `~/policyengine-app-v2/app/src/data/posts/posts.json`
+- Live blog: https://policyengine.org/us/blog and https://policyengine.org/uk/blog


### PR DESCRIPTION
## Summary
- Adds new skill for finding existing PolicyEngine blog posts, research, and published analyses
- Useful for preparing talks, pitches, or finding credibility proof points
- Documents blog post location (`policyengine-app-v2/app/src/data/posts/articles/`)
- Highlights key posts like the 10 Downing Street adoption story

## Use case
When I needed to prepare a lightning talk submission connecting PolicyEngine to "abundance/state capacity", I had to manually search for the No. 10 blog post. This skill would have helped Claude find it proactively.

## Test plan
- [ ] Verify skill is discoverable in Claude Code
- [ ] Test that skill triggers when asking about PolicyEngine research/proof points

🤖 Generated with [Claude Code](https://claude.com/claude-code)