### PR TITLE
feat: add SessionStart hook for automatic agent selection

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,10 +1,4 @@
-# Placeholder for next changelog entry
-# Format:
-# - bump: patch/minor/major
-#   changes:
-#     added:
-#       - "Description"
-#     changed:
-#       - "Description"
-#     removed:
-#       - "Description"
+- bump: minor
+  changes:
+    added:
+      - SessionStart hook that auto-detects PolicyEngine repos and injects instructions to use specialized plugin agents (rules-engineer, ci-fixer, pr-pusher, etc.) instead of general-purpose agents

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,6 +1,13 @@
 {
-  "description": "Cosilico architecture enforcement - tax logic ONLY in .rac files",
+  "description": "PolicyEngine plugin hooks - agent auto-selection and architecture enforcement",
   "hooks": {
+    "SessionStart": [
+      {
+        "type": "prompt",
+        "prompt": "POLICYENGINE AGENT AUTO-SELECTION: Detect if the current working directory contains a PolicyEngine repository.\n\nCheck for these repo patterns:\n- policyengine-us (or contains policyengine_us/)\n- policyengine-uk (or contains policyengine_uk/)\n- policyengine-core\n- policyengine-api\n- policyengine-app\n\nIf in a PolicyEngine country model repo (policyengine-us or policyengine-uk):\nINJECT THIS INSTRUCTION: 'IMPORTANT: When spawning subagents for implementation work in this repo, use the specialized PolicyEngine plugin agents instead of general-purpose agents:\n\n| Task | Use Agent |\n|------|----------|\n| Implement variables/parameters | complete:country-models:rules-engineer |\n| Create tests | complete:country-models:test-creator |\n| Fix CI failures | complete:country-models:ci-fixer |\n| Push PR with formatting | complete:country-models:pr-pusher |\n| Review implementation | complete:country-models:implementation-validator |\n\nThese agents automatically load PolicyEngine skills, run make format before commits, and follow PE coding standards. Do NOT use general-purpose agents for policyengine-us/uk work.'\n\nIf in policyengine-api:\nINJECT: 'Use complete:api:api-reviewer for API-related agent work.'\n\nIf in policyengine-app:\nINJECT: 'Use complete:app:app-reviewer for frontend-related agent work.'\n\nIf not in a PolicyEngine repo: return empty/no injection.",
+        "timeout": 5
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",


### PR DESCRIPTION
## Summary

When working in PolicyEngine repos, the plugin now automatically injects instructions to use specialized agents instead of general-purpose agents.

**Problem:** When spawning subagents for policyengine-us/uk work, users had to manually know to use `complete:country-models:rules-engineer` instead of `general-purpose`. This led to:
- Agents not loading PolicyEngine skills
- Lint failures from not running `make format`
- Not following PE coding standards

**Solution:** Add a `SessionStart` hook that detects the repo type and injects agent recommendations:

| Repo | Recommended Agents |
|------|-------------------|
| policyengine-us | `complete:country-models:*` (rules-engineer, ci-fixer, pr-pusher, test-creator) |
| policyengine-uk | `complete:country-models:*` (same agents, different domain skill) |
| policyengine-api | `complete:api:api-reviewer` |
| policyengine-app | `complete:app:app-reviewer` |

## Test plan

- [ ] Start new Claude Code session in policyengine-us directory
- [ ] Verify SessionStart hook fires and injects agent recommendations
- [ ] Spawn an agent and verify it uses the correct plugin agent type
- [ ] Confirm agent loads skills and runs `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)