### PR TITLE
docs: add divide-by-zero avoidance pattern to vectorization skill

### DIFF
--- a/skills/technical-patterns/policyengine-vectorization-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-vectorization-skill/SKILL.md
@@ -178,7 +178,89 @@ return where(
 
 ---
 
-## 5. Advanced Patterns
+## 5. CRITICAL: Avoiding Divide-by-Zero Warnings
+
+### The Problem with `where()` for Division
+
+`where()` evaluates **BOTH branches** before selecting. This causes divide-by-zero warnings even when the zero case wouldn't be selected:
+
+```python
+# ❌ WRONG - causes divide-by-zero warning
+proportion = where(
+    total_income > 0,
+    person_income / total_income,  # Still evaluated when total_income = 0!
+    0,
+)
+```
+
+### ✅ CORRECT: Use `np.divide` with `where` Parameter
+
+```python
+# ✅ CORRECT - only divides where mask is True
+# The `out` parameter IS the default value - positions where mask=False keep this value
+mask = total_income > 0
+proportion = np.divide(
+    person_income,
+    total_income,
+    out=np.zeros_like(person_income),  # Default to 0 where mask is False
+    where=mask,
+)
+```
+
+**How `out` works as the default:**
+- `out=np.zeros_like(...)` → default is 0
+- `out=np.ones_like(...)` → default is 1
+- Positions where `where=False` keep their `out` value unchanged
+
+### ✅ CORRECT: Alternative Mask Pattern
+
+```python
+# ✅ CORRECT - traditional mask assignment
+proportion = np.zeros_like(total_income)
+mask = total_income > 0
+proportion[mask] = person_income[mask] / total_income[mask]
+```
+
+### Common Use Cases
+
+**Proportional allocation (e.g., splitting deductions between spouses):**
+```python
+# Allocate proportionally by income
+unit_income = tax_unit.sum(person_income)
+mask = unit_income > 0
+share = np.divide(
+    person_income,
+    unit_income,
+    out=np.zeros_like(person_income),
+    where=mask,
+)
+# Default share when unit has no income
+share = where(mask, share, where(is_head, 1.0, 0.0))
+```
+
+**Calculating ratios:**
+```python
+# AGI ratio for credit calculations
+mask = us_agi != 0
+ratio = np.divide(
+    state_agi,
+    us_agi,
+    out=np.zeros_like(us_agi),
+    where=mask,
+)
+```
+
+### Real Examples in Codebase
+
+See these files for reference implementations:
+- `taxable_social_security.py` - person share of unit benefits
+- `mo_taxable_income.py` - AGI share allocation
+- `md_two_income_subtraction.py` - head's share of couple income
+- `ok_child_care_child_tax_credit.py` - AGI ratio
+
+---
+
+## 6. More Advanced Patterns
 
 ### Pattern: Vectorized Lookup Tables
 
@@ -230,7 +312,7 @@ total = household.sum(eligible_income)
 
 ---
 
-## 6. Performance Implications
+## 7. Performance Implications
 
 ### Why Vectorization Matters
 
@@ -250,7 +332,7 @@ benefits = where(incomes > 1000, 500, 100)  # All at once!
 
 ---
 
-## 7. Testing for Vectorization Issues
+## 8. Testing for Vectorization Issues
 
 ### Signs Your Code Isn't Vectorized
 


### PR DESCRIPTION
## Summary

Adds a new section to the vectorization skill explaining how to avoid divide-by-zero warnings when using divisions in vectorized code.

**Problem:** Using `where()` for conditional division causes divide-by-zero warnings because `where()` evaluates BOTH branches before selecting:
```python
# ❌ Causes warning even when total > 0
proportion = where(total > 0, x / total, 0)
```

**Solution:** Use `np.divide` with `where` parameter:
```python
# ✅ Only divides where mask is True
mask = total > 0
proportion = np.divide(x, total, out=np.zeros_like(x), where=mask)
```

Also clarifies that the `out` parameter serves as the default value for positions where `mask=False`.

References real codebase examples:
- `taxable_social_security.py`
- `mo_taxable_income.py`
- `md_two_income_subtraction.py`
- `ok_child_care_child_tax_credit.py`

## Test plan

- [x] Pattern validated on PR #7303 (MO capital loss) and PR #7294 (MS capital loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)