### PR TITLE
Add .values weight-stripping warnings to skill guidance

### DIFF
--- a/skills/data-science/microdf-skill/SKILL.md
+++ b/skills/data-science/microdf-skill/SKILL.md
@@ -126,6 +126,17 @@ income_series.gini()
 income_series.percentile(50)
 ```
 
+**WARNING: `.values` and `.to_numpy()` strip weights.** These methods now emit a `UserWarning` because they return plain numpy arrays where operations like `.mean()` are unweighted. Always use MicroSeries methods directly for weighted calculations:
+
+```python
+# ❌ WRONG - strips weights, .mean() is unweighted
+ms.values.mean()
+ms.to_numpy().mean()
+
+# ✅ CORRECT - weighted automatically
+ms.mean()
+```
+
 ### Working with PolicyEngine Results
 
 ```python

--- a/skills/domain-knowledge/policyengine-uk-skill/SKILL.md
+++ b/skills/domain-knowledge/policyengine-uk-skill/SKILL.md
@@ -225,6 +225,8 @@ universal_credit = simulation.calculate("universal_credit", 2025)
 household_net_income = simulation.calculate("household_net_income", 2025)
 ```
 
+**IMPORTANT for population-level analysis (Microsimulation):** `calc()` and `calculate()` return MicroSeries with embedded weights. Never call `.values` or `.to_numpy()` on them — this strips weights and makes aggregations like `.mean()` unweighted. Keep results as MicroSeries and use its methods directly.
+
 **Common Variables:**
 
 **Income:**

--- a/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
@@ -20,6 +20,25 @@ description: |
 
 **MicroSeries handles all weighting automatically. Never access .weights or do manual weight math.**
 
+### NEVER strip weights with .values
+
+`calc()` and `calculate()` return MicroSeries with embedded weights. Calling `.values` strips them and returns a plain numpy array where `.mean()` is **unweighted**.
+
+```python
+# ❌ WRONG - .values strips weights, .mean() is UNWEIGHTED
+result = sim.calc("household_net_income", period=2025).values
+wrong_mean = result.mean()  # Unweighted!
+
+# ❌ WRONG - same problem with .to_numpy()
+result = sim.calc("household_net_income", period=2025).to_numpy()
+
+# ✅ CORRECT - keep as MicroSeries, all operations are weighted
+result = sim.calc("household_net_income", period=2025)
+correct_mean = result.mean()  # Weighted automatically!
+```
+
+### Correct patterns
+
 ```python
 # ✅ CORRECT - MicroSeries handles everything
 change = reformed.calc('household_net_income', period=2026, map_to='person') - \


### PR DESCRIPTION
## Summary
- Updated 3 skills to explicitly warn against `.values` stripping weights from MicroSeries
- Companion to PolicyEngine/microdf#278 which adds runtime `UserWarning` for `.values`/`.to_numpy()`

## Changes
- **microsimulation skill**: Added "NEVER strip weights with .values" section with correct/incorrect code examples
- **UK skill**: Added warning near `.calculate()` documentation about keeping results as MicroSeries
- **microdf skill**: Documented that `.values` and `.to_numpy()` now warn

## Test plan
- [x] Read updated skill files to confirm guidance is clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)