### PR TITLE
Add parameter structure transition pattern to skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.1] - 2026-02-18
+
+### Added
+
+- Add parameter structure transition pattern (flat to bracket) to parameter-patterns and variable-patterns skills
+- Add new bracket pattern using `.inf` for adding brackets to existing scales without breaking prior years
+
 ## [3.7.0] - 2026-02-16 17:53:45
 
 ### Added

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,5 @@
-- bump: minor
+- bump: patch
   changes:
     added:
       - Add parameter structure transition pattern (flat to bracket) to parameter-patterns and variable-patterns skills
+      - Add new bracket pattern using .inf for adding brackets to existing scales without breaking prior years

--- a/skills/technical-patterns/policyengine-variable-patterns-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-variable-patterns-skill/SKILL.md
@@ -932,6 +932,7 @@ class wa_capital_gains_tax(Variable):
 **When NOT to use this pattern:**
 - ❌ The parameter structure is the same across all periods (just access it normally)
 - ❌ The branching depends on a per-entity condition like income or age (use `where()` instead)
+- ❌ A new bracket was added to an existing scale using `.inf` (no variable changes needed — `.calc()` works as before; see parameter patterns skill)
 
 ---
 


### PR DESCRIPTION
## Summary

Add a new pattern to both `policyengine-parameter-patterns` and `policyengine-variable-patterns` skills for handling **parameter structure transitions** — when a parameter's YAML structure type changes over time (e.g., flat rate → marginal brackets).

## What's added

### Parameter patterns skill
- New subsection **"Parameter Structure Transitions (Flat → Bracket)"** under Section 6 (Common Parameter Patterns)
- Documents the folder split pattern: `rate/flat.yaml` + `rate/incremental.yaml` + `rate/flat_applies.yaml`
- Includes when-to-use and when-not-to-use guidance

### Variable patterns skill
- New subsection **"Handling Parameter Structure Transitions"** under Common Implementation Patterns
- Documents the `if p.rate.flat_applies:` branching pattern
- Explains why `if` (not `where`) is correct for parameter-level toggles

## Motivation

This pattern came up in [policyengine-us PR #7374](https://github.com/PolicyEngine/policyengine-us/pull/7374) (Washington capital gains tax 2025 update), where the rate changed from a flat 7% to a tiered 7%/9.9% structure via ESSB 5813. Without this pattern, the bracket structure would retroactively apply to pre-2025 years.

🤖 Generated with [Claude Code](https://claude.com/claude-code)