### PR TITLE
Add Gini and inequality methods to microsimulation skill

### DIFF
--- a/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
@@ -91,13 +91,39 @@ sim = Microsimulation(dataset='hf://policyengine/policyengine-us-data/districts/
 
 ## Key MicroSeries Methods
 
+MicroSeries (from [microdf](https://github.com/PolicyEngine/microdf)) handles all weighting automatically — see the `microdf` skill for full documentation.
+
 ```python
 income = sim.calc('household_net_income', period=2026, map_to='person')
 
+# Basic weighted statistics
 income.mean()           # Weighted mean
 income.sum()            # Weighted sum
 income.median()         # Weighted median
 (income > 50000).mean() # Weighted share meeting condition
+
+# Inequality metrics (see microdf skill for more)
+income.gini()           # Weighted Gini coefficient
+```
+
+### Inequality & Distributional Analysis
+
+Use built-in MicroSeries methods — never reimplement Gini or other inequality metrics manually:
+
+```python
+baseline_income = baseline.calc('household_net_income', period=2026, map_to='person')
+reformed_income = reformed.calc('household_net_income', period=2026, map_to='person')
+
+# Gini coefficient change
+print(f"Baseline Gini: {baseline_income.gini():.4f}")
+print(f"Reform Gini:   {reformed_income.gini():.4f}")
+
+# Poverty rate (boolean MicroSeries)
+in_poverty = baseline.calc('spm_unit_is_in_spm_poverty', map_to='person', period=2026)
+print(f"SPM poverty rate: {in_poverty.mean():.1%}")
+
+# Decile-level analysis
+income.decile_rank()    # Assign decile ranks (1-10)
 ```
 
 ## Finding Parameter Paths


### PR DESCRIPTION
## Summary

- Add `.gini()`, `.decile_rank()`, and poverty rate patterns to the microsimulation skill's "Key MicroSeries Methods" section
- Add cross-reference to the `microdf` skill for full inequality/poverty documentation
- Add a "Inequality & Distributional Analysis" subsection with baseline vs. reform Gini comparison example

## Context

Discovered while reviewing [ai-inequality PR #23](https://github.com/PolicyEngine/ai-inequality/pull/23): a contributor reimplemented weighted Gini from scratch with a buggy formula (`+1/total_weight` bias correction that breaks for survey-weighted data) instead of calling the built-in `MicroSeries.gini()`.

The microdf skill documents `.gini()` extensively, but the microsimulation skill — which is the entry point for anyone doing population-level analysis — only listed `.mean()`, `.sum()`, `.median()` as key methods. There was no bridging example showing `sim.calc(...).gini()`, so the two skills were siloed.

Testing with an independent agent confirmed that without this cross-reference, an LLM following the microsimulation skill alone would likely write its own Gini function rather than discover the built-in one.

## Test plan

- [ ] Verify the microsimulation skill now surfaces `.gini()` when asked about inequality measurement
- [ ] Confirm the cross-reference to microdf skill is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)