### PR TITLE
Add GitHub Pages sitemap limitations to SEO audit

### DIFF
--- a/agents/app/seo-crawlability-checker.md
+++ b/agents/app/seo-crawlability-checker.md
@@ -45,6 +45,8 @@ Search for `sitemap.xml` in the same locations as robots.txt.
 
 **If not found:** Report FAIL — search engines can't discover pages efficiently.
 
+**GitHub Pages caveat:** Even if `sitemap.xml` is valid, Google Search Console cannot fetch sitemaps from `.github.io` domains (returns "Sitemap could not be read"). This is a GitHub infrastructure limitation. Flag this if the hosting is GitHub Pages without a custom domain.
+
 ### 3. Check Routing Architecture
 
 Determine the routing strategy by examining:
@@ -107,6 +109,8 @@ Determine the hosting platform:
 - Check if `base` path in build config matches the repository name
 - Check if CNAME file exists (custom domain)
 - Note: GitHub Pages doesn't support server-side redirects or SSR
+- **CRITICAL: Check for `.nojekyll` file** in `public/` or repo root. Without this file, GitHub Pages runs Jekyll processing which can mangle XML files (sitemap.xml, robots.txt). If missing, report FAIL.
+- **Sitemap + Google Search Console warning:** GitHub Pages on `.github.io` domains blocks automated fetches from Googlebot. Google Search Console will show "Sitemap could not be read" even if the sitemap is valid. The fix is using a **custom domain** (CNAME). If the site uses `.github.io` without a custom domain, flag this as a known limitation and recommend setting up a custom domain for proper sitemap indexing.
 
 **Multiple deploy configs:** Some repos have Dockerfile + vercel.json + cloudbuild.yaml. Identify which is the PRIMARY deployment and use that for canonical URL recommendations.
 

--- a/skills/technical-patterns/seo-checklist-skill/SKILL.md
+++ b/skills/technical-patterns/seo-checklist-skill/SKILL.md
@@ -225,14 +225,28 @@ Place in `public/sitemap.xml`:
 
 For apps with multiple distinct pages, add each URL as a separate `<url>` entry.
 
+### .nojekyll (GitHub Pages only)
+
+**Always add an empty `.nojekyll` file to `public/`** when deploying to GitHub Pages. Without it, GitHub runs Jekyll processing which can mangle XML files like `sitemap.xml` and `robots.txt`, preventing Google from reading them.
+
+### GitHub Pages Sitemap Limitation
+
+**Known issue:** Google Search Console cannot fetch sitemaps from `.github.io` domains. Even with a valid, accessible `sitemap.xml`, Search Console will show "Sitemap could not be read." This is a GitHub infrastructure limitation — GitHub blocks automated Googlebot fetches.
+
+**Workarounds:**
+- **Custom domain (recommended):** Set up a CNAME (e.g., `tool.policyengine.org`) pointing to `org.github.io`. Sitemaps work correctly on custom domains.
+- **URL Inspection:** Manually request indexing via Search Console's URL Inspection tool — this works even when sitemap fetching doesn't.
+- **Backlinks:** Links from other indexed sites (e.g., policyengine.org embedding/linking to the tool) will cause Google to discover and index the page without needing the sitemap.
+
 ### Google Search Console
 
 After deploying robots.txt and sitemap.xml:
 1. Go to https://search.google.com/search-console
-2. Add your domain as a property
-3. Verify ownership (HTML file, DNS, or meta tag)
+2. Add your domain as a property (use URL prefix for GitHub Pages subpaths)
+3. Verify ownership (HTML meta tag is easiest for GitHub Pages)
 4. Submit your sitemap URL
-5. Monitor indexing status and search performance
+5. If on `.github.io`: expect "Sitemap could not be read" — use URL Inspection instead
+6. Monitor indexing status and search performance
 
 ---
 
@@ -351,6 +365,7 @@ This is not something the plugin can check, but it's important context: the poli
 - [ ] `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image` present
 - [ ] `robots.txt` exists in build output root
 - [ ] `sitemap.xml` exists in build output root
+- [ ] `.nojekyll` exists in `public/` (GitHub Pages only — prevents XML mangling)
 - [ ] Page content is in the HTML (not only JS-rendered)
 - [ ] `<html lang="en">` attribute set
 


### PR DESCRIPTION
## Summary

- Add `.nojekyll` file check to the crawlability agent — GitHub Pages runs Jekyll by default which mangles XML files like `sitemap.xml`
- Add warning that `.github.io` domains block Googlebot from fetching sitemaps (Google Search Console shows "Sitemap could not be read")
- Document workarounds: custom domain, URL Inspection tool, backlinks
- Add `.nojekyll` to the quick reference checklist in the SEO skill

Discovered this issue when Google Search Console consistently failed to fetch a valid sitemap from a GitHub Pages deployment.

## Test plan

- [ ] Run `/audit-seo` on a GitHub Pages repo — verify it flags missing `.nojekyll` and warns about sitemap limitation
- [ ] Run `/audit-seo` on a Vercel repo — verify GitHub Pages warnings don't appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)