### PR TITLE
Unify neutrality rules into writing skill

### DIFF
--- a/agents/shared/neutrality-reviewer.md
+++ b/agents/shared/neutrality-reviewer.md
@@ -8,95 +8,22 @@ tools: Read, Glob, Grep
 
 You review all PolicyEngine output — research papers, blog posts, interactive tool text, documentation, PR descriptions, and project communications — for analytical neutrality. PolicyEngine is a nonpartisan 501(c)(3). Every piece of output must let the reader draw their own conclusions from the data.
 
-This goes beyond writing style (covered by policyengine-writing-skill). That skill catches promotional language and vague adjectives. You catch subtler problems: advocacy disguised as findings, speculative claims presented as results, and framing choices that nudge readers toward a policy position.
+## Neutrality rules
 
-## CRITICAL: Automatic rejection triggers
+Apply the full analytical neutrality rules from the PolicyEngine writing skill. The five categories to check:
 
-**Flag as MUST FIX if the output exhibits ANY of these:**
+1. **Value-laden language** — "unfortunately", "successfully", "disproportionate" (without benchmark), "helping/hurting" (instead of "increases/decreases by $X")
+2. **Policy prescriptions disguised as findings** — "the government should...", ranking policy options without model support, "for policy, this means..."
+3. **Speculative claims presented as results** — "plausibly achievable", "low-cost relative to...", predictions about political feasibility, directional claims about unmeasured relationships
+4. **One-sided framing of tradeoffs** — benefits without costs, "lower bound" stacking without acknowledging offsetting assumptions, "free lunch" framing
+5. **Scope overreach** — conclusions beyond model scope, static results applied to dynamic settings without caveat, adding estimates from different frameworks as if additive
 
-1. **Policy prescriptions disguised as findings**:
-   - "The government should..." or "Policymakers should..."
-   - "This implies we need to..." or "Reform X is needed"
-   - Ranking policy options without model support for the ranking
-   - Claiming one policy channel is superior to another without modeling both
-   - "For policy, this means..." in a section that reports model results
+## Review process
 
-2. **Speculative claims presented as results**:
-   - "Plausibly achievable" without evidence for plausibility
-   - "Low-cost relative to..." without evidence for the cost
-   - "Per unit of political effort" or similar unmeasured quantities
-   - Predictions about political feasibility or implementation difficulty
-   - Directional claims about unmeasured relationships ("would likely increase")
-
-3. **One-sided framing of tradeoffs**:
-   - Presenting benefits of a policy without discussing its costs
-   - Describing an intervention as "merely" doing X (understating difficulty)
-   - Comparing a modeled quantity to an unmodeled quantity to make the modeled one look favorable
-   - "Free lunch" framing: claiming a policy has no downside
-   - Repeated "lower bound" / "conservative estimate" assertions without acknowledging factors pushing the other direction
-
-4. **Scope overreach**:
-   - Conclusions that extend beyond what the model can show
-   - Applying static model results to dynamic settings without caveat
-   - Treating model parameters as if they were policy levers
-   - Adding estimates from different models/frameworks as if they were straightforwardly additive
-
-5. **Implicit value judgments**:
-   - "Unfortunately" or "successfully" attached to policy outcomes
-   - "Disproportionate" without defining the benchmark
-   - "Fair share" or "equitable" without specifying the normative standard
-   - Characterizing a policy as "helping" or "hurting" (use "increases/decreases net income by $X")
-
-## Review focus areas
-
-### 1. Claims vs. findings
-- Does each claim follow directly from the model or data?
-- Are comparative claims supported by the analysis?
-- Are counterfactual claims clearly labeled as model-dependent?
-- Are adjectives/adverbs backed by specific numbers?
-
-### 2. Policy neutrality
-- Does the output present findings without recommending specific policies?
-- If policy implications are discussed, are multiple channels presented evenhandedly?
-- Are the costs and tradeoffs of each option acknowledged?
-- Would a reader with different policy priors find the framing fair?
-
-### 3. Speculative language
-- Are phrases like "plausibly", "likely", "would probably" backed by evidence?
-- Are comparisons to unmeasured quantities flagged as informal?
-- Are political or implementation feasibility claims avoided?
-
-### 4. Scope honesty
-- Does the output clearly state what the model can and cannot show?
-- Are limitations genuine (not perfunctory)?
-- Does the abstract/summary accurately reflect the scope?
-
-### 5. Evenhandedness
-- Are alternatives given comparable treatment?
-- Are opposing considerations acknowledged?
-- Is the tone descriptive rather than persuasive?
-
-## Common problems in PolicyEngine output
-
-### Blog posts
-- Framing a policy as "helping families" instead of "increasing net income by $X for households with income between $Y and $Z"
-- Comparing PolicyEngine results favorably to other models without noting methodological differences
-- Stating policy costs without mentioning what the policy achieves (or vice versa)
-
-### Research papers
-- "Lower bound" / "conservative" stacking: asserting the estimate is conservative at every decision point without acknowledging assumptions that push the other way
-- Policy prescription sections that go beyond model scope
-- Informal magnitude comparisons designed to make results seem large or small
-
-### Interactive tools
-- Default scenarios that highlight dramatic results
-- Labels or descriptions that frame outcomes positively or negatively
-- "You could save $X" instead of "Your net income changes by $X"
-
-### Project communications
-- Claiming PolicyEngine is "more accurate" than alternatives (say: "projects X% higher/lower than Y")
-- Describing nonpartisan analysis as "supporting" a particular reform
-- Using results to advocate for or against specific legislation
+1. Read all files in scope (paper chapters, blog post, tool text, etc.)
+2. For each file, check every claim against the five categories above
+3. Flag issues with the specific quote, why it's non-neutral, and a suggested neutral alternative
+4. Note strengths — what the output does well in maintaining neutrality
 
 ## Output format
 

--- a/skills/documentation/policyengine-writing-skill/SKILL.md
+++ b/skills/documentation/policyengine-writing-skill/SKILL.md
@@ -103,11 +103,15 @@ Use sentence case (capitalize only the first word and proper nouns) for all head
 ## Key Findings
 ```
 
-## Neutral, Objective Tone
+## Analytical neutrality
 
-Describe what policies do without value judgments. Let readers draw their own conclusions from the data.
+PolicyEngine is a nonpartisan 501(c)(3). Every piece of output must let the reader draw their own conclusions from the data. This section covers both surface-level tone and deeper structural neutrality.
 
-**✅ Correct (Neutral):**
+### Value-laden language
+
+Describe what policies do without value judgments.
+
+**✅ Correct:**
 ```
 The reform reduces poverty by 3.2% and raises inequality by 0.16%
 Single filers with earnings between $8,000 and $37,000 see their net incomes increase
@@ -116,7 +120,7 @@ PolicyEngine projects higher costs than other organizations
 The top income decile receives 42% of total benefits
 ```
 
-**❌ Wrong (Value judgments):**
+**❌ Wrong:**
 ```
 The reform successfully reduces poverty by 3.2% but unfortunately raises inequality
 Low-income workers finally see their net incomes increase
@@ -124,6 +128,125 @@ The tax changes benefit most residents
 PolicyEngine provides more accurate cost estimates
 The wealthiest households receive a disproportionate share of benefits
 ```
+
+Specific words and phrases to avoid:
+- "Unfortunately" or "successfully" attached to policy outcomes
+- "Disproportionate" without defining the benchmark
+- "Fair share" or "equitable" without specifying the normative standard
+- "Helping" or "hurting" — use "increases/decreases net income by $X"
+- "Merely" or "just" to understate difficulty
+
+### Policy prescriptions disguised as findings
+
+Never recommend policies. Present findings and let readers decide.
+
+**❌ Wrong:**
+```
+The government should simplify the tax code
+This implies we need to expand the credit
+For policy, this means targeting simplification efforts at middle-income households
+```
+
+**✅ Correct:**
+```
+The model estimates that reducing misperception by 5 percentage points lowers
+deadweight loss by 66%. The relative cost-effectiveness of approaches to
+achieving this reduction depends on implementation costs outside the model's scope.
+```
+
+Also avoid:
+- Ranking policy options without model support for the ranking
+- Claiming one policy channel is superior to another without modeling both
+- "Policymakers should..." or "Reform X is needed"
+
+### Speculative claims presented as results
+
+Every claim must be backed by model output or cited evidence.
+
+**❌ Wrong:**
+```
+Plausibly achievable through minor administrative changes
+Low-cost relative to the welfare gains at stake
+Per unit of political effort, simplification dominates rate cuts
+```
+
+**✅ Correct:**
+```
+The model estimates a 66% reduction in deadweight loss from a 5 percentage point
+decrease in σ. Whether this reduction is achievable, and at what cost, depends on
+factors outside the model's scope.
+```
+
+Also avoid:
+- Predictions about political feasibility or implementation difficulty
+- Directional claims about unmeasured relationships ("would likely increase")
+- Comparisons to unmeasured quantities to make modeled results look favorable
+
+### One-sided framing of tradeoffs
+
+Present both sides. If you discuss benefits, discuss costs. If you discuss costs, discuss what the policy achieves.
+
+**❌ Wrong:**
+```
+The reform reduces child poverty at minimal cost
+Even the most conservative estimate shows significant gains
+```
+
+**✅ Correct:**
+```
+The reform reduces the Supplemental Poverty Measure by 3.2%, affecting 2.1 million
+children. The sensitivity range spans 1.8% to 4.7% depending on behavioral
+assumptions. The estimated cost is $14.3 billion annually.
+```
+
+Also avoid:
+- "Lower bound" / "conservative estimate" stacking without acknowledging assumptions that push the other direction
+- "Free lunch" framing: claiming a policy has no downside
+- Comparing a modeled quantity to an unmodeled quantity to make the modeled one look favorable
+
+### Scope honesty
+
+State what the model can and cannot show. Don't extend conclusions beyond the analysis.
+
+**❌ Wrong:**
+```
+The results demonstrate that tax simplification is welfare-improving
+Adding the misperception cost to Skinner's policy uncertainty cost gives 0.5% of GDP
+```
+
+**✅ Correct:**
+```
+Within the model, reducing σ by 5 percentage points lowers aggregate deadweight loss
+by approximately two-thirds. Whether real-world interventions can achieve this
+reduction is an empirical question beyond the model's scope.
+```
+
+Also avoid:
+- Applying static model results to dynamic settings without caveat
+- Treating model parameters as if they were policy levers
+- Adding estimates from different models/frameworks as if straightforwardly additive
+
+### Common neutrality problems by output type
+
+**Blog posts:**
+- Framing a policy as "helping families" instead of "increasing net income by $X for households with income between $Y and $Z"
+- Comparing PolicyEngine results favorably to other models without noting methodological differences
+- Stating policy costs without mentioning what the policy achieves (or vice versa)
+
+**Research papers:**
+- "Lower bound" / "conservative" stacking: asserting the estimate is conservative at every decision point without acknowledging assumptions pushing the other way
+- Policy prescription sections that go beyond model scope
+- Informal magnitude comparisons designed to make results seem large or small
+
+**Interactive tools:**
+- Default scenarios that highlight dramatic results
+- Labels or descriptions that frame outcomes positively or negatively
+- "You could save $X" instead of "Your net income changes by $X"
+
+**Project communications:**
+- Claiming PolicyEngine is "more accurate" than alternatives (say: "projects X% higher/lower than Y")
+- Describing nonpartisan analysis as "supporting" a particular reform
+- Using results to advocate for or against specific legislation
 
 ## Precise Verbs Over Adverbs
 
@@ -555,7 +678,11 @@ Before publishing, verify:
 - [ ] Use active voice throughout
 - [ ] Include specific numbers for all claims
 - [ ] Use sentence case for all headings
-- [ ] Maintain neutral, objective tone
+- [ ] No policy prescriptions disguised as findings
+- [ ] No speculative claims presented as results
+- [ ] Tradeoffs presented evenhandedly (costs and benefits)
+- [ ] Conclusions stay within model scope
+- [ ] No implicit value judgments
 - [ ] Choose precise verbs over vague adverbs
 - [ ] Include concrete household examples
 - [ ] Present data in tables


### PR DESCRIPTION
## Summary
- Moves the full analytical neutrality taxonomy into `policyengine-writing-skill` so writers have the rules while writing, not just caught in review
- Slims down the `neutrality-reviewer` agent to reference the shared rules and focus on review mechanics/output format
- Adds 5 neutrality checklist items to the writing checklist

## What changed
- **Writing skill**: Expanded "Neutral, objective tone" (5 examples) → "Analytical neutrality" section with 5 subsections covering policy prescriptions, speculative claims, one-sided framing, scope overreach, and value judgments, plus common problems by output type
- **Neutrality reviewer agent**: Now references the writing skill's rules rather than duplicating them; focuses on review process and output format

## Why
The writing skill and neutrality reviewer covered the same domain ("how PE should communicate") but the split was confusing — someone writing a blog post had to know about both. The neutrality rules belong in the writer's head while writing, not just caught in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)