### PR TITLE
Add counterintuitive results check

### DIFF
--- a/agents/shared/neutrality-reviewer.md
+++ b/agents/shared/neutrality-reviewer.md
@@ -17,11 +17,12 @@ Apply the full analytical neutrality rules from the PolicyEngine writing skill. 
 3. **Speculative claims presented as results** — "plausibly achievable", "low-cost relative to...", predictions about political feasibility, directional claims about unmeasured relationships
 4. **One-sided framing of tradeoffs** — benefits without costs, "lower bound" stacking without acknowledging offsetting assumptions, "free lunch" framing
 5. **Scope overreach** — conclusions beyond model scope, static results applied to dynamic settings without caveat, adding estimates from different frameworks as if additive
+6. **Unexplained counterintuitive results** — any subgroup whose impact has the opposite sign from the headline result without an explanation of the mechanism (e.g. households losing from a tax cut due to SALT interactions, or losing from a benefit expansion due to cliff effects)
 
 ## Review process
 
 1. Read all files in scope (paper chapters, blog post, tool text, etc.)
-2. For each file, check every claim against the five categories above
+2. For each file, check every claim against the six categories above
 3. Flag issues with the specific quote, why it's non-neutral, and a suggested neutral alternative
 4. Note strengths — what the output does well in maintaining neutrality
 

--- a/skills/documentation/policyengine-writing-skill/SKILL.md
+++ b/skills/documentation/policyengine-writing-skill/SKILL.md
@@ -226,6 +226,32 @@ Also avoid:
 - Treating model parameters as if they were policy levers
 - Adding estimates from different models/frameworks as if straightforwardly additive
 
+### Counterintuitive results
+
+When results show impacts that go against directional expectations, always explain the mechanism. Unexplained surprising results erode trust and leave readers to guess — or assume the analysis is wrong.
+
+Common counterintuitive patterns to watch for:
+- Households losing from a tax rate reduction (SALT deduction interactions, AMT thresholds, benefit phase-outs)
+- Households losing from a benefit expansion (cliff effects, interactions with other means-tested programs)
+- A reform that raises revenue but increases poverty (or vice versa)
+- Impacts that differ in sign across income groups in unexpected ways
+- A "simplification" that raises effective rates for some filers
+
+**❌ Wrong:**
+```
+The tax rate reduction increases net income for 82% of households.
+```
+
+**✅ Correct:**
+```
+The tax rate reduction increases net income for 82% of households. The 4.3%
+of households that see a net income decrease are primarily filers in the
+$100,000–$200,000 range who lose more from the corresponding SALT deduction
+cap than they gain from the lower rate.
+```
+
+Rule: if any subgroup's impact has the opposite sign from the headline result, explain why.
+
 ### Common neutrality problems by output type
 
 **Blog posts:**
@@ -683,6 +709,7 @@ Before publishing, verify:
 - [ ] Tradeoffs presented evenhandedly (costs and benefits)
 - [ ] Conclusions stay within model scope
 - [ ] No implicit value judgments
+- [ ] Counterintuitive results explained (opposite-sign subgroups, unexpected losers/winners)
 - [ ] Choose precise verbs over vague adverbs
 - [ ] Include concrete household examples
 - [ ] Present data in tables


### PR DESCRIPTION
## Summary
- When results show impacts that go against directional expectations, the output must explain the mechanism
- Added to writing skill (new subsection + checklist item) and neutrality reviewer (6th category)

## Examples
- Households losing from a tax rate reduction (SALT interactions, AMT, benefit phase-outs)
- Households losing from a benefit expansion (cliff effects, means-tested program interactions)
- Revenue increases that coincide with poverty increases (or vice versa)

Addresses Pavel's suggestion in #blog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)