### PR TITLE
Update time-limit guidance and testing patterns

### DIFF
--- a/agents/country-models/ci-fixer.md
+++ b/agents/country-models/ci-fixer.md
@@ -202,6 +202,7 @@ grep -A 20 "employment_income" /policyengine_us/tests/policy/baseline/gov/states
 3. **Fix Test Failures**
    - Analyze failure output
    - Fix test or implementation based on documentation
+   - When adding test cases to existing files, always append at the bottom — never insert in the middle (renumbering existing cases creates noisy diffs)
    - Re-run tests locally
 
 4. **Iterate Until Pass**

--- a/agents/country-models/document-collector.md
+++ b/agents/country-models/document-collector.md
@@ -45,37 +45,39 @@ This ensures you have the complete patterns and standards loaded for reference t
    - Official calculators and examples
    - Amendment histories and effective dates
 
-**CRITICAL: Flag Non-Simulatable Rules**
+**CRITICAL: Document Time-Limited Rules**
 
-When you encounter the following in documentation, **FLAG them as non-simulatable**:
+When you encounter time-limited rules (disregards that expire after N months, rates that change by calendar month), **document them clearly** so they can be properly implemented. These ARE simulatable.
 
-⚠️ **CANNOT be fully simulated** (single-period architecture):
-- Time limits (ANY lifetime or cumulative limits)
-- Work history requirements (worked X of last Y periods)
-- Waiting periods (benefits start after X time)
-- Progressive sanctions (escalating penalties)
-- Any rule requiring historical tracking
+✅ **Time-limited disregards** — supported via calendar month or applicable_months split:
+- Disregard rates that change by calendar month (e.g., "50% for months 1-6, 35% for months 7-9")
+- Disregards that expire after N months (e.g., "75% disregard for first 4 months")
+- Split-year rates (e.g., "100% disregard for first 6 months, partial for remaining")
 
-⚠️ **Partially simulatable** (implement with limitations):
-- Time-limited deductions (e.g., "75% disregard for first 4 months")
-- First X months benefits (apply as if always available)
+✅ **Applicant vs. Recipient distinctions** — supported via `is_tanf_enrolled` (separate concept from time limits):
+- Use when regulation explicitly defines different rules by enrollment status (e.g., TX: applicants get 1/3, recipients get 90%)
 
 Mark these clearly in your documentation:
 ```markdown
-### ⚠️ Non-Simulatable Rules (Architecture Limitation)
-- **Time Limit**: [X]-month lifetime limit [CANNOT ENFORCE - requires history]
-- **Work Requirement**: Must work [X] hours/week for [Y] months [CANNOT TRACK]
+### Time-Limited Disregards
+- **Months 1-6**: 50% disregard
+- **Months 7-9**: 35% disregard
+- **Months 10-12**: 25% disregard
+- **Source**: [citation]
 
-### ⚠️ Partially Simulatable (Time-Limited Benefits)
-- **Earned Income Disregard**: 75% for first 4 months [APPLIED ALWAYS - cannot track months]
-- **Work Expense Deduction**: $120 for first 12 months [APPLIED ALWAYS - cannot track duration]
+### Applicant vs. Recipient Rules (if applicable)
+- **Earned Income Disregard (Applicant)**: 20%
+- **Earned Income Disregard (Recipient)**: 50%
+- **Source**: [citation]
 ```
 
-✅ **CAN be simulated** (current point-in-time):
-- Current income limits
-- Current resource limits
+✅ **CAN be simulated:**
+- Current income limits and resource limits
 - Current benefit calculations
 - Current household composition
+- Current deductions and disregards
+- Time-limited disregard schedules
+- Applicant vs. recipient branching
 
 2. **Handle PDF Documents (Download and Extract)**
 

--- a/agents/country-models/edge-case-generator.md
+++ b/agents/country-models/edge-case-generator.md
@@ -211,6 +211,8 @@ For each detected pattern:
 
 ## Output Format
 
+**CRITICAL: When adding cases to an existing test file, always append new cases at the bottom. Never insert in the middle — this renumbers existing cases and creates noisy diffs.**
+
 Generate test files with clear documentation:
 
 ```yaml

--- a/agents/country-models/parameter-architect.md
+++ b/agents/country-models/parameter-architect.md
@@ -86,23 +86,25 @@ When creating parameters, you MUST:
 
 ### Step 3: Identify Parameterizable Values
 
-**FIRST: Check policyengine-variable-patterns-skill "PolicyEngine Architecture Constraints"**
+**FIRST: Check policyengine-variable-patterns-skill "Modeling Time-Limited Rules"**
 
-**DO NOT parameterize non-simulatable rules:**
-- ❌ Time limits (lifetime/cumulative limits)
-- ❌ Work history requirements
-- ❌ Waiting periods
-- ❌ Progressive sanctions
-- ❌ Month counters for enforcement
+**DO parameterize time-limited values:**
+- ✅ Time-varying disregard rates — bracket-style parameters keyed by month
+- ✅ Split-year rates — use `applicable_months` parameter
+- ✅ Applicant vs. recipient rates (when regulation defines them separately) — separate parameter files
 
-**DO parameterize (but document limitations):**
-- ⚠️ Time-limited deduction amounts (note they're time-limited in description)
-- ⚠️ First X months disregard rates (note the time limitation)
-
-Example for time-limited parameter:
+Example for time-varying disregard (bracket by month):
 ```yaml
-description: Indiana excludes this share of earned income from TANF calculations for the first 4 consecutive months of employment.
-# NOTE: PolicyEngine applies this disregard without tracking employment months
+# .../time_limited_percentage/rate.yaml
+brackets:
+  - threshold:
+      2024-01-01: 1
+    amount:
+      2024-01-01: 0.5    # Months 1-6: 50%
+  - threshold:
+      2024-01-01: 7
+    amount:
+      2024-01-01: 0.25   # Months 7-12: 25%
 ```
 
 **DO parameterize point-in-time values:**

--- a/agents/country-models/rules-engineer.md
+++ b/agents/country-models/rules-engineer.md
@@ -416,32 +416,21 @@ return max_(countable, 0)
 - Disregard percentage pattern
 - Rare cases where unearned has separate deductions
 
-### Step 3.5: Filter Out Non-Simulatable Rules (CRITICAL)
+### Step 3.5: Time-Limited Rules
 
-**PolicyEngine Architecture Constraints (from loaded skill)**
+**PolicyEngine supports modeling time-limited disregards. DO implement these — DO NOT skip them.**
 
-Before parameterizing ANYTHING, verify it CAN be simulated:
+Refer to the **policyengine-variable-patterns-skill** "Modeling Time-Limited Rules" section for patterns:
 
-**DO NOT parameterize or implement:**
-- ❌ Time limits (lifetime benefit limits)
-- ❌ Work history requirements (ANY historical requirement)
-- ❌ Waiting periods (ANY delayed eligibility)
-- ❌ Progressive sanctions (ANY escalating rules)
-- ❌ Enforcement of time-limited rules
-
-**DO implement with comments:**
-- ⚠️ Time-limited deductions (implement but note the limitation)
-- ⚠️ First X months disregards (apply as if always available)
-
-Example for time-limited deductions:
+1. **Calendar month** — Use when disregard varies by month of the year:
 ```python
-def formula(spm_unit, period, parameters):
-    # NOTE: This disregard only applies for first 4 months of employment
-    # PolicyEngine cannot track employment duration, so we apply it always
-    # Actual rule: [State Code Citation]
-    disregard = p.earned_income_disregard_rate
-    return earned * (1 - disregard)
+month = period.start.month
+tlp_rate = p.time_limited_percentage.rate.calc(month)
 ```
+
+2. **`applicable_months` split** — Use when year is split into periods with different rates.
+
+**Separate concept: `is_tanf_enrolled`** — Use when a state's regulation explicitly defines different rules for applicants vs. recipients (e.g., TX: applicants get 1/3, recipients get 90%). This is an applicant/recipient policy distinction, not time-limit modeling.
 
 ### Step 4: Create Parameters
 
@@ -587,7 +576,7 @@ When invoked to fix issues, you MUST:
 | **Regulation reference** | Complex calculations | `# Per OAR 461-155-0020(2)(a)` |
 | **Calculation order** | Multi-step formulas | `# Step 1: Gross income before disregards` |
 | **Non-obvious logic** | When code doesn't match intuition | `# Apply disregard BEFORE adding unearned (state-specific)` |
-| **Limitation notes** | Non-simulatable rules | `# NOTE: 4-month limit cannot be tracked` |
+| **Implementation notes** | Non-obvious design choices | `# Disregard rate varies by calendar month` |
 
 ### ❌ DON'T - Obvious or verbose comments
 ```python
@@ -619,7 +608,6 @@ def formula(spm_unit, period, parameters):
     # Step 2: Apply disregards BEFORE combining (state-specific order)
     net_earned = max_(adult_earned - p.earned_income_disregard, 0)
 
-    # NOTE: 4-month transitional disregard cannot be tracked
     return net_earned + gross_unearned
 ```
 
@@ -628,7 +616,7 @@ def formula(spm_unit, period, parameters):
 2. **YES: Regulation references** for complex or non-obvious calculations
 3. **YES: Step numbers** for multi-step formulas (helps reviewers follow logic)
 4. **YES: Non-obvious logic** when calculation order or approach differs from intuition
-5. **YES: Brief NOTE** about PolicyEngine limitations (one line)
+5. **YES: Brief NOTE** about implementation decisions (one line)
 6. **NO multi-paragraph explanations** - keep it to one line per comment
 7. **Aim for 2-4 comments per formula** - not zero, not excessive
 

--- a/changelog.d/time-limit-testing-guidance.changed.md
+++ b/changelog.d/time-limit-testing-guidance.changed.md
@@ -1,0 +1,1 @@
+Replace outdated single-period time-limit guidance with implementable patterns (calendar month, applicable_months), add negative income benefit cap test pattern, and enforce appending test cases at bottom of files

--- a/commands/fix-pr.md
+++ b/commands/fix-pr.md
@@ -213,7 +213,7 @@ Add missing tests for:
 - [variable2]: Missing zero income case
 - [variable3]: Missing maximum household size case
 
-Add to existing test files.
+Always append new cases at the bottom of existing test files. Never insert in the middle — this renumbers existing cases and creates noisy diffs.
 ```
 
 ### Step 3C: Fix Naming Issues

--- a/skills/technical-patterns/policyengine-code-style-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-code-style-skill/SKILL.md
@@ -441,9 +441,9 @@ def formula(spm_unit, period, parameters):
 ### Comment Rules
 
 1. **NO comments explaining what code does** - variable names should be clear
-2. **OK: Brief NOTE about PolicyEngine limitations** (one line):
+2. **OK: Brief NOTE about implementation decisions** (one line):
    ```python
-   # NOTE: Time limit cannot be tracked in PolicyEngine
+   # NOTE: Disregard rate varies by calendar month
    ```
 3. **NO multi-line explanations** of what the code calculates
 

--- a/skills/technical-patterns/policyengine-testing-patterns-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-testing-patterns-skill/SKILL.md
@@ -122,6 +122,27 @@ Use numbered cases with descriptions:
 - name: Case 1 - single parent  # Wrong punctuation
 ```
 
+### Adding Cases to Existing Test Files
+
+**CRITICAL: Always append new test cases at the bottom of the file.** Never insert cases in the middle of existing tests.
+
+```yaml
+# Existing file has Cases 1-3
+# ✅ CORRECT - Add Case 4 at the bottom:
+- name: Case 3, income above threshold.
+  ...
+
+- name: Case 4, new edge case scenario.
+  ...
+
+# ❌ WRONG - Inserting between existing cases and renumbering:
+- name: Case 1, ...
+- name: Case 2, new case inserted here.    # Renumbered!
+- name: Case 3, was previously Case 2.     # Renumbered!
+```
+
+**Why:** Inserting in the middle forces renumbering of existing cases, which creates noisy diffs and makes review harder. Appending at the bottom keeps existing cases untouched.
+
 ### Person Names
 
 Use generic sequential names:
@@ -481,6 +502,34 @@ Before submitting tests:
         snap: 200  # Receives SNAP
   output:
     program_categorical_eligible: true
+```
+
+### Negative Income — Benefit Cap
+
+Always include a test that verifies benefits are capped at the maximum payment amount when countable income is negative. This prevents the bug where `max_benefit - (-N) = max_benefit + N`, inflating benefits beyond the payment standard.
+
+```yaml
+# Tests that benefits are capped at the maximum payment amount,
+# even when countable income is negative.
+# Prevents: benefit = max - (-5M) = 5M+
+- name: Case N, negative countable income does not inflate benefit.
+  period: 2025-01
+  input:
+    people:
+      person1:
+        age: 30
+        self_employment_income: -60_000_000  # -$5M/month
+      person2:
+        age: 8
+    spm_units:
+      spm_unit:
+        members: [person1, person2]
+    households:
+      household:
+        members: [person1, person2]
+        state_code: XX
+  output:
+    xx_tanf: 300  # Capped at max payment standard, not 5M+
 ```
 
 ---

--- a/skills/technical-patterns/policyengine-variable-patterns-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-variable-patterns-skill/SKILL.md
@@ -27,98 +27,61 @@ Essential patterns for creating PolicyEngine variables for government benefit pr
 
 ---
 
-## PolicyEngine Architecture Constraints
+## Modeling Time-Limited Rules
 
-### What CANNOT Be Simulated (Single-Period Limitation)
+PolicyEngine supports modeling time-limited disregards. **DO implement these — DO NOT skip them.**
 
-**CRITICAL: PolicyEngine uses single-period simulation architecture**
+### Not Yet Modeled
 
-The following CANNOT be implemented and should be SKIPPED when found in documentation:
+Lifetime benefit limits (e.g., federal 60-month TANF limit) are not yet modeled in PolicyEngine. Don't implement these, but don't add comments claiming they're architecturally impossible — they may be added in the future.
 
-#### 1. Time Limits and Lifetime Counters
-**Cannot simulate:**
-- ANY lifetime benefit limits (X months total)
-- ANY time windows (X months within Y period)
-- Benefit clocks and countable months
-- Cumulative time tracking
+### Pattern 1: Calendar Month — Time-Varying Disregard
 
-**Why:** Requires tracking benefit history across multiple periods. PolicyEngine simulates one period at a time with no state persistence.
+Use when a disregard rate changes based on the month of the year. Uses `period.start.month` to get the calendar month (January=1, February=2, etc.).
 
-**What to do:** Document in comments but DON'T parameterize or implement:
-```python
-# NOTE: [State] has [X]-month lifetime limit on [Program] benefits
-# This cannot be simulated in PolicyEngine's single-period architecture
-```
-
-#### 2. Work History Requirements
-**Cannot simulate:**
-- "Must have worked 6 of last 12 months"
-- "Averaged 30 hours/week over past quarter"
-- Prior employment verification
-- Work participation rate tracking
-
-**Why:** Requires historical data from previous periods.
-
-#### 3. Waiting Periods and Benefit Delays
-**Cannot simulate:**
-- "3-month waiting period for new residents"
-- "Benefits start month after application"
-- Retroactive eligibility
-- Benefit recertification cycles
-
-**Why:** Requires tracking application dates and eligibility history.
-
-#### 4. Progressive Sanctions and Penalties
-**Cannot simulate:**
-- "First violation: 1-month sanction, Second: 3-month, Third: permanent"
-- Graduated penalties
-- Strike systems
-
-**Why:** Requires tracking violation history.
-
-#### 5. Asset Spend-Down Over Time
-**Cannot simulate:**
-- Medical spend-down across months
-- Resource depletion tracking
-- Accumulated medical expenses
-
-**Why:** Requires tracking expenses and resources across periods.
-
-### What CAN Be Simulated (With Caveats)
-
-PolicyEngine CAN simulate point-in-time eligibility and benefits:
-- ✅ Current month income limits
-- ✅ Current month resource limits
-- ✅ Current benefit calculations
-- ✅ Current household composition
-- ✅ Current deductions and disregards
-
-### Time-Limited Benefits That Affect Current Calculations
-
-**Special Case: Time-limited deductions/disregards**
-
-When a deduction or disregard is only available for X months:
-- **DO implement the deduction** (assume it applies)
-- **DO add a comment** explaining the time limitation
-- **DON'T try to track or enforce the time limit**
-
-Example:
 ```python
 class state_tanf_countable_earned_income(Variable):
     def formula(spm_unit, period, parameters):
         p = parameters(period).gov.states.xx.tanf.income
         earned = spm_unit("tanf_gross_earned_income", period)
 
-        # NOTE: In reality, this 75% disregard only applies for first 4 months
-        # of employment. PolicyEngine cannot track employment duration, so we
-        # apply the disregard assuming the household qualifies.
-        # Actual rule: [State Code Citation]
-        disregard_rate = p.earned_income_disregard_rate  # 0.75
-
-        return earned * (1 - disregard_rate)
+        month = period.start.month
+        tlp_rate = p.time_limited_percentage.rate.calc(month)
+        return earned * (1 - tlp_rate)
 ```
 
-**Rule: If it requires history or future tracking, it CANNOT be fully simulated - but implement what we can and document limitations**
+**Parameter structure** — bracket by month:
+```yaml
+# .../time_limited_percentage/rate.yaml
+brackets:
+  - threshold:
+      1997-07-01: 1
+    amount:
+      1997-07-01: 0.5    # Months 1-6: 50%
+  - threshold:
+      1997-07-01: 7
+    amount:
+      1997-07-01: 0.35   # Months 7-9: 35%
+  - threshold:
+      1997-07-01: 10
+    amount:
+      1997-07-01: 0.25   # Months 10-12: 25%
+```
+
+### Pattern 2: `applicable_months` Split
+
+Use when a state splits the year into periods with different disregard rates.
+
+```python
+class state_tanf_countable_earned_income(Variable):
+    def formula(spm_unit, period, parameters):
+        p = parameters(period).gov.states.xx.tanf.income
+        # First 6 months: 100% disregard (if eligible)
+        # Remaining 6 months: partial disregard
+        full_disregard_months = p.full_disregard.applicable_months  # 6
+        remaining_months = MONTHS_IN_YEAR - full_disregard_months
+        # ... apply appropriate rate based on period
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace outdated "cannot simulate time limits" guidance across 5 agent/skill files with implementable patterns (calendar month, `applicable_months`)
- Add "not yet modeled" note for lifetime limits (e.g., 60-month TANF) — don't implement but don't claim architecturally impossible
- Add negative income benefit cap test pattern to prevent `max - (-N) = max + N` bug
- Enforce appending test cases at bottom of existing files (never insert in middle)

## Files changed
- `skills/technical-patterns/policyengine-variable-patterns-skill/SKILL.md` — core time-limit patterns
- `skills/technical-patterns/policyengine-testing-patterns-skill/SKILL.md` — negative income test + append rule
- `skills/technical-patterns/policyengine-code-style-skill/SKILL.md` — updated comment example
- `agents/country-models/rules-engineer.md` — updated Step 3.5
- `agents/country-models/parameter-architect.md` — updated Step 3
- `agents/country-models/document-collector.md` — updated flagging section
- `agents/country-models/ci-fixer.md` — append test cases rule
- `agents/country-models/edge-case-generator.md` — append test cases rule
- `commands/fix-pr.md` — append test cases rule

## Test plan
- [ ] Verify agents load updated skills correctly via `--plugin-dir`
- [ ] Confirm time-limit patterns render correctly in skill output
- [ ] Test that new TANF implementations follow calendar month / applicable_months patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)