### PR TITLE
Add /create-new-component command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -136,12 +136,15 @@
       "license": "MIT",
       "agents": [
         "./agents/app/app-reviewer.md",
+        "./agents/app/component-test-writer.md",
+        "./agents/app/design-token-validator.md",
         "./agents/app/seo-meta-checker.md",
         "./agents/app/seo-crawlability-checker.md",
         "./agents/app/seo-performance-checker.md",
         "./agents/app/seo-content-checker.md"
       ],
       "commands": [
+        "./commands/create-new-component.md",
         "./commands/create-pr.md",
         "./commands/review-pr.md",
         "./commands/fix-pr.md",
@@ -256,6 +259,8 @@
       "agents": [
         "./agents/api/api-reviewer.md",
         "./agents/app/app-reviewer.md",
+        "./agents/app/component-test-writer.md",
+        "./agents/app/design-token-validator.md",
         "./agents/app/seo-meta-checker.md",
         "./agents/app/seo-crawlability-checker.md",
         "./agents/app/seo-performance-checker.md",
@@ -290,6 +295,7 @@
         "./commands/audit-seo.md",
         "./commands/audit-state-tax.md",
         "./commands/backdate-program.md",
+        "./commands/create-new-component.md",
         "./commands/create-pr.md",
         "./commands/encode-policy.md",
         "./commands/encode-reform.md",

--- a/agents/app/component-test-writer.md
+++ b/agents/app/component-test-writer.md
@@ -1,0 +1,119 @@
+# Component Test Writer Agent
+
+## Role
+You are the Component Test Writer Agent. Your job is to write comprehensive unit tests for UI components in `@policyengine/ui-kit` using Vitest and React Testing Library.
+
+## Core Responsibilities
+
+### 1. Test every component
+For ALL components provided, write tests that cover:
+- **Rendering:** Component renders without crashing
+- **Props:** All props are applied correctly (variants, sizes, states, custom classNames)
+- **Variants:** Each CVA variant produces the correct visual output
+- **Accessibility:** Correct ARIA attributes, semantic HTML roles
+- **User interaction:** Click handlers, input changes, keyboard events where applicable
+- **Edge cases:** Empty/null props, overflow content, boundary values
+
+### 2. Test framework and conventions
+
+**Stack:**
+- Vitest as test runner
+- React Testing Library for component rendering
+- `@testing-library/jest-dom` for DOM matchers
+
+**Setup file** (`vitest.setup.ts`):
+```ts
+import '@testing-library/jest-dom/vitest';
+```
+
+**Test file naming:** `ComponentName.test.tsx` alongside the component
+
+**Import pattern:**
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ComponentName } from './ComponentName';
+```
+
+### 3. Test patterns
+
+**Basic render test:**
+```tsx
+it('renders without crashing', () => {
+  render(<Button>Click me</Button>);
+  expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument();
+});
+```
+
+**Variant test:**
+```tsx
+it('applies primary variant classes', () => {
+  render(<Button variant="primary">Test</Button>);
+  const button = screen.getByRole('button');
+  expect(button.className).toMatch(/primary/);
+});
+```
+
+**Props test:**
+```tsx
+it('applies custom className', () => {
+  render(<Button className="tw:mt-4">Test</Button>);
+  const button = screen.getByRole('button');
+  expect(button.className).toContain('tw:mt-4');
+});
+```
+
+**Interaction test:**
+```tsx
+it('calls onClick handler when clicked', () => {
+  const handleClick = vi.fn();
+  render(<Button onClick={handleClick}>Test</Button>);
+  fireEvent.click(screen.getByRole('button'));
+  expect(handleClick).toHaveBeenCalledOnce();
+});
+```
+
+**Forwarded ref test:**
+```tsx
+it('forwards ref', () => {
+  const ref = { current: null };
+  render(<Button ref={ref}>Test</Button>);
+  expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+});
+```
+
+### 4. Quality standards
+- Every exported component must have at least 3 tests
+- Test behavior, not implementation details
+- Use `screen` queries (getByRole, getByText, getByLabelText) over container queries
+- Prefer `getByRole` for accessibility verification
+- Mock external dependencies (Recharts, etc.) when needed
+- Group tests with `describe` blocks per component
+
+### 5. Chart component testing
+For Recharts-based components, mock Recharts since it doesn't render in jsdom:
+```tsx
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) => <div data-testid="responsive-container">{children}</div>,
+  BarChart: ({ children }: any) => <div data-testid="bar-chart">{children}</div>,
+  // ... etc
+}));
+```
+
+## Workflow
+
+1. Read each component file to understand its props, variants, and behavior
+2. Write a comprehensive test file for each component
+3. Place test files next to their components (e.g., `src/primitives/Button.test.tsx`)
+4. Run the full test suite (`bun run test`) and fix any failures
+5. Report coverage summary
+
+## Output format
+
+For each component, output:
+```
+## ComponentName.test.tsx
+- X tests written
+- Covers: rendering, variants (N), props, interaction, ref forwarding
+- Status: PASS / FAIL (with details)
+```

--- a/agents/app/design-token-validator.md
+++ b/agents/app/design-token-validator.md
@@ -1,0 +1,65 @@
+# Design Token Validator Agent
+
+## Role
+You are the Design Token Validator Agent. Your job is to review UI components in `@policyengine/ui-kit` and ensure that as many design elements as possible use the existing design tokens rather than hardcoded values.
+
+## Core Responsibilities
+
+### 1. Audit all style values
+For every component file provided, scan for:
+- Hardcoded hex colors (e.g., `#319795`, `#FFFFFF`) — replace with token references (`primary-500`, `white`, etc.)
+- Hardcoded pixel values for spacing (e.g., `p-4`, `gap-8`) — replace with spacing tokens (`tw:p-lg`, `tw:gap-md`, etc.)
+- Hardcoded font sizes (e.g., `text-[14px]`) — replace with typography tokens (`tw:text-sm`, etc.)
+- Hardcoded border radius (e.g., `rounded-[6px]`) — replace with radius tokens (`tw:rounded-md`, etc.)
+- Hardcoded font families — replace with the configured font (`Inter` via `--pe-font-family-primary`)
+
+### 2. Token reference
+Use the design tokens defined in `@policyengine/ui-kit`:
+
+**Colors (Tailwind classes with `tw:` prefix):**
+- Primary: `tw:bg-primary-500`, `tw:text-primary-600`, etc.
+- Gray: `tw:bg-gray-50`, `tw:text-gray-700`, etc.
+- Semantic: `tw:text-text-primary`, `tw:text-text-secondary`, `tw:bg-bg-primary`
+- Status: `tw:text-success`, `tw:text-error`, `tw:text-warning`
+
+**Spacing (mapped to Tailwind via theme):**
+- `xs` (4px), `sm` (8px), `md` (12px), `lg` (16px), `xl` (20px), `2xl` (24px), `3xl` (32px), `4xl` (48px)
+
+**Typography:**
+- Font sizes: `xs` (12px), `sm` (14px), `base` (16px), `lg` (18px), `xl` (20px), `2xl` (24px), `3xl` (28px)
+- Font weights: `font-normal`, `font-medium`, `font-semibold`, `font-bold`
+
+**Border radius:**
+- `sm` (4px), `md` (6px), `lg` (8px)
+
+### 3. Tailwind v4 with prefix
+All Tailwind classes in `@policyengine/ui-kit` use the `tw:` prefix (configured via `@import 'tailwindcss' prefix(tw)`). Ensure all token-based classes use this prefix.
+
+### 4. CVA variant patterns
+Components use `class-variance-authority` (CVA) for variants. When reviewing CVA definitions, ensure variant values also use tokens:
+```ts
+// BAD
+const variants = cva('bg-[#319795] text-[14px] p-[8px]');
+
+// GOOD
+const variants = cva('tw:bg-primary-500 tw:text-sm tw:p-sm');
+```
+
+## Workflow
+
+1. Read each component file
+2. List every hardcoded value found
+3. For each, provide the token-based replacement
+4. Apply the modifications directly to the files
+5. Report a summary: number of values replaced, any values that have no token equivalent (these are acceptable if truly custom)
+
+## Output format
+
+For each component, output:
+```
+## ComponentName.tsx
+- Replaced `#319795` → `tw:text-primary-500` (3 occurrences)
+- Replaced `p-4` → `tw:p-lg` (2 occurrences)
+- Kept `w-[280px]` — no token equivalent (layout-specific)
+Total: X replacements, Y kept as-is
+```

--- a/changelog.d/add-create-new-component-command.added.md
+++ b/changelog.d/add-create-new-component-command.added.md
@@ -1,0 +1,1 @@
+Add /create-new-component command with design-token-validator and component-test-writer agents for building ui-kit components.

--- a/commands/create-new-component.md
+++ b/commands/create-new-component.md
@@ -1,0 +1,260 @@
+---
+description: Build new UI components for @policyengine/ui-kit — with design token validation, tests, visual preview, and PR creation
+---
+
+# Create new component
+
+Builds one or more new components for the `@policyengine/ui-kit` library. Handles the full lifecycle: research existing patterns, build with design tokens, validate token usage, write tests, preview visually, and open a PR.
+
+## Prerequisites
+
+The `policyengine-ui-kit` repo must be cloned locally. If not found, clone it:
+```bash
+gh repo clone PolicyEngine/policyengine-ui-kit
+```
+
+All work happens in the `policyengine-ui-kit` repo directory.
+
+## Step 1: Gather requirements
+
+Use `AskUserQuestion` to ask the user:
+
+1. **Component description** — What component(s) do you need? Describe their purpose, behavior, and any variants.
+
+Parse the description to identify:
+- Component names (PascalCase, e.g., `Tooltip`, `ProgressBar`, `Accordion`)
+- Which category they belong to: `primitives`, `layout`, `inputs`, `display`, or `charts`
+- Expected props, variants, and states
+
+## Step 2: Research app-v2 for similar components
+
+Before building from scratch, search `PolicyEngine/policyengine-app-v2` for similar implementations:
+
+```bash
+# Search app-v2 for components with similar names or purposes
+find /path/to/policyengine-app-v2/app/src -name "*.tsx" | xargs grep -li "COMPONENT_NAME_PATTERN"
+
+# Also check the design-system package
+find /path/to/policyengine-app-v2/packages/design-system -name "*.tsx" | xargs grep -li "COMPONENT_NAME_PATTERN"
+
+# Check Mantine usage patterns for the same component type
+grep -r "Mantine.*COMPONENT_TYPE" /path/to/policyengine-app-v2/app/src --include="*.tsx" -l
+```
+
+If similar components exist in app-v2:
+- Study their props interface, variant patterns, and behavior
+- Adapt the design and UX, but rebuild using the ui-kit's Tailwind v4 + CVA stack
+- Do NOT copy Mantine-dependent code — translate it to Tailwind utility classes
+
+If nothing similar exists in app-v2:
+- Research common patterns for that component type
+- Design props and variants that are consistent with existing ui-kit components
+
+## Step 3: Build the component(s)
+
+**Tech stack (mandatory):**
+- React 19 with `forwardRef`
+- TypeScript with strict types
+- Tailwind CSS v4 with `tw:` prefix on all utility classes
+- CVA (`class-variance-authority`) for variant management
+- `cn()` utility from `@/utils/cn` for class merging
+- Design tokens from the ui-kit's Tailwind theme (colors, spacing, typography, radius)
+
+**File structure for each component:**
+```
+src/<category>/ComponentName.tsx
+```
+
+**Component template:**
+```tsx
+import { cva, type VariantProps } from 'class-variance-authority';
+import { forwardRef, type HTMLAttributes } from 'react';
+import { cn } from '../utils/cn';
+
+const componentVariants = cva(
+  'tw:base-classes-here',
+  {
+    variants: {
+      variant: {
+        default: 'tw:variant-classes',
+        // ... more variants
+      },
+      size: {
+        sm: 'tw:size-classes',
+        md: 'tw:size-classes',
+        lg: 'tw:size-classes',
+      },
+    },
+    defaultVariants: { variant: 'default', size: 'md' },
+  },
+);
+
+export interface ComponentNameProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof componentVariants> {
+  // Additional props here
+}
+
+export const ComponentName = forwardRef<HTMLDivElement, ComponentNameProps>(
+  ({ variant, size, className, children, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(componentVariants({ variant, size }), className)}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+);
+ComponentName.displayName = 'ComponentName';
+```
+
+**Rules:**
+- ALL Tailwind classes must use the `tw:` prefix
+- ALL colors, spacing, font sizes, and radii must reference design tokens — no hardcoded hex values, no arbitrary pixel values
+- Export the component and its props interface from the category barrel (`src/<category>/index.ts`)
+- Export from the main barrel (`src/index.ts`)
+- Build ALL components the user requested — do not skip any
+
+## Step 4: Design token validation agent
+
+Launch the **Design Token Validator Agent** (`agents/app/design-token-validator.md`) to audit every component file created in Step 3.
+
+The agent will:
+1. Scan all new component files for hardcoded values
+2. Replace hardcoded colors, spacing, font sizes, and radii with token-based Tailwind classes
+3. Report what was replaced and what was kept
+
+Review the agent's output. If it made changes, verify they look correct.
+
+## Step 5: Add components to a preview page
+
+Create or update `demo/Demo.tsx` to include a new section showcasing ALL new components with realistic example data.
+
+```tsx
+// Add a new section for each component
+<section>
+  <h2 className="tw:text-2xl tw:font-bold tw:mb-lg">ComponentName</h2>
+  <div className="tw:flex tw:flex-wrap tw:gap-md">
+    {/* Render every variant, size, and state */}
+    <ComponentName variant="default">Example</ComponentName>
+    <ComponentName variant="primary" size="lg">Large primary</ComponentName>
+    {/* ... all combinations */}
+  </div>
+</section>
+```
+
+**Important:** Include ALL new components on the preview page, not just some.
+
+## Step 6: Launch preview and iterate with user
+
+Start the demo dev server:
+```bash
+cd /path/to/policyengine-ui-kit
+bun run dev:demo
+```
+
+Tell the user:
+> The demo server is running at http://localhost:5173/demo/index.html — scroll to the new component section to preview your components.
+
+Then use `AskUserQuestion` to ask:
+> Do the components look correct? Please review and either approve or describe changes you'd like.
+
+**This is iterative.** If the user requests changes:
+1. Apply the requested modifications
+2. The dev server will hot-reload automatically
+3. Ask the user to review again
+4. Repeat until the user approves
+
+Do NOT proceed to Step 7 until the user explicitly approves the components.
+
+## Step 7: Component test writer agent
+
+After user approval, launch the **Component Test Writer Agent** (`agents/app/component-test-writer.md`) to write unit tests for ALL new components.
+
+The agent will:
+1. Read each new component file
+2. Write comprehensive test files (rendering, props, variants, interaction, ref forwarding)
+3. Place tests next to components (`src/<category>/ComponentName.test.tsx`)
+4. Run `bun run test` and fix any failures
+
+Verify all tests pass:
+```bash
+cd /path/to/policyengine-ui-kit
+bun run test
+```
+
+If tests fail, fix them before proceeding.
+
+## Step 8: Create changelog fragment
+
+Add a towncrier changelog fragment:
+```bash
+echo "Add <ComponentName>, <ComponentName2>, ... components." > changelog.d/add-COMPONENT_NAME.added.md
+```
+
+## Step 9: Commit, push, and open PR
+
+```bash
+# Create feature branch
+git checkout -b add-COMPONENT_NAME-component
+
+# Stage all new and modified files
+git add src/<category>/ComponentName.tsx
+git add src/<category>/ComponentName.test.tsx
+git add src/<category>/index.ts
+git add src/index.ts
+git add demo/Demo.tsx
+git add changelog.d/add-COMPONENT_NAME.added.md
+
+# Commit
+git commit -m "Add ComponentName component with tests"
+
+# Push
+git push -u origin add-COMPONENT_NAME-component
+```
+
+Create a PR with details about the new components and their test coverage:
+```bash
+gh pr create --repo PolicyEngine/policyengine-ui-kit \
+  --title "Add ComponentName component" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `ComponentName` component to `@policyengine/ui-kit`
+- <Describe each component, its variants, and purpose>
+
+## Components added
+- `ComponentName` — <brief description>
+  - Variants: <list variants>
+  - Props: <list key props>
+
+## Testing
+- Unit tests written with Vitest + React Testing Library
+- Tests cover: rendering, all variants, props, interaction, ref forwarding
+- All tests passing
+
+## Design token compliance
+- All colors reference design tokens (no hardcoded hex)
+- All spacing uses token-based Tailwind classes
+- All typography uses token scale
+- Validated by design-token-validator agent
+
+## Test plan
+- [ ] Run `bun run dev:demo` and verify components render correctly
+- [ ] Run `bun run test` and verify all tests pass
+- [ ] Review component API matches existing ui-kit conventions
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Report the PR URL to the user.
+
+## Reference
+
+See these skills and agents for detailed guidance:
+- `policyengine-design-skill` — Design token values and usage
+- `policyengine-app-skill` — app-v2 component patterns to reference
+- `agents/app/design-token-validator.md` — Automated design token compliance
+- `agents/app/component-test-writer.md` — Automated test writing


### PR DESCRIPTION
## Summary
- Add `/create-new-component` slash command for building new `@policyengine/ui-kit` components with full lifecycle management
- Add **design-token-validator** agent that audits components for hardcoded values and replaces them with design token references
- Add **component-test-writer** agent that writes Vitest + React Testing Library tests for all new components

## Command workflow
1. Gather component requirements from user
2. Research app-v2 for similar components to adapt
3. Build with Tailwind v4 + CVA + design tokens (`tw:` prefix)
4. Run design-token-validator agent to enforce token compliance
5. Add all components to demo preview page
6. Launch dev server and iterate with user until approved
7. Run component-test-writer agent for unit tests
8. Create towncrier changelog fragment
9. Commit, push, and open PR

## Test plan
- [ ] Verify marketplace.json is valid JSON
- [ ] Verify command and agents are registered in `app-development` and `complete` plugins
- [ ] Test command invocation with `/create-new-component`

🤖 Generated with [Claude Code](https://claude.com/claude-code)