### PR TITLE
Document niceTicks domain requirement and dollar formatting

### DIFF
--- a/changelog.d/niceticks-domain-fix.changed.md
+++ b/changelog.d/niceticks-domain-fix.changed.md
@@ -1,0 +1,1 @@
+Document niceTicks domain requirement and negative dollar formatting.

--- a/skills/tools-and-apis/policyengine-interactive-tools-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-interactive-tools-skill/SKILL.md
@@ -436,13 +436,20 @@ const fontFamily = getCssVar("--pe-font-family-primary");
 
 <BarChart data={data}>
   <CartesianGrid stroke={gridColor} />
-  <XAxis niceTicks tick={{ fontSize: 12, fontFamily }} />
-  <YAxis niceTicks tick={{ fontSize: 12, fontFamily }} />
+  <XAxis niceTicks domain={["auto", "auto"]} tick={{ fontSize: 12, fontFamily }} />
+  <YAxis niceTicks domain={["auto", "auto"]} tick={{ fontSize: 12, fontFamily }} />
   <Bar dataKey="value" fill={primaryColor} />
 </BarChart>
 ```
 
 **Always use `niceTicks`** on `<XAxis>` and `<YAxis>` — this snaps tick values to human-friendly round numbers (e.g., `[0, 5, 10, 15]` instead of `[0, 3.5, 7, 10.5]`). Accepts `true` (boolean) or enum values `'auto'`, `'nice'`, `'equidistant'`, `'none'`. Default to `niceTicks` (boolean) for simplicity.
+
+**Always set `domain={["auto", "auto"]}`** on axes using `niceTicks` — the default recharts domain `[0, 'auto']` clamps the minimum to 0, which breaks tick calculation for data that doesn't start at 0 (e.g., all-negative values). Setting both ends to `"auto"` lets recharts compute the domain from the data.
+
+**Format negative dollar values as `-$100`** not `$-100` — use a custom `tickFormatter` like:
+```jsx
+tickFormatter={(v) => v < 0 ? `-$${Math.abs(v)}` : `$${v}`}
+```
 
 **Never pass hardcoded hex values** like `fill="#319795"` to Recharts — always resolve from CSS variables.
 
@@ -492,7 +499,8 @@ Test API responses against Python fixtures for numerical accuracy. See `PolicyEn
 - [ ] **Zero hardcoded hex colors** — all colors via `var(--pe-color-*)`
 - [ ] **Zero hardcoded font names** — all fonts via `var(--pe-font-family-primary)`
 - [ ] Recharts charts use `getCssVar()` helper for SVG props (font, colors)
-- [ ] Recharts axes use `niceTicks` for human-friendly tick values
+- [ ] Recharts axes use `niceTicks` with `domain={["auto", "auto"]}` for human-friendly tick values
+- [ ] Negative dollar values formatted as `-$100` not `$-100`
 - [ ] PE logo is an actual image, not styled text
 - [ ] Sentence case on all UI text
 - [ ] Data pattern chosen (precomputed JSON / precomputed CSV / API / Modal)


### PR DESCRIPTION
## Summary
- Add `domain={["auto", "auto"]}` requirement alongside `niceTicks` in Recharts examples and checklist
- Document that default recharts domain `[0, 'auto']` breaks niceTicks for non-zero-origin data
- Add negative dollar formatting rule (`-$100` not `$-100`) with example tickFormatter

Learned from snap-bbce-repeal where niceTicks wasn't producing nice numbers due to the default domain clamping min to 0.

## Test plan
- [ ] Verify SKILL.md renders correctly
- [ ] Checklist items are complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)