### PR TITLE
Audit and fix all 41 policyengine-claude skills

### DIFF
--- a/changelog.d/skill-audit-fixes.changed.md
+++ b/changelog.d/skill-audit-fixes.changed.md
@@ -1,0 +1,1 @@
+Audit and fix all 41 skills: pip→uv pip (14 skills), npm→bun (4 skills), remove Streamlit references (3 skills), fix deprecated brand colors, fix wrong CTC parameter path, add trigger phrases to 10 skills, remove emoji from headers (12 skills), trim standards skill from 820→363 lines, fix changelog documentation.

--- a/skills/analysis/policyengine-analysis-skill/SKILL.md
+++ b/skills/analysis/policyengine-analysis-skill/SKILL.md
@@ -13,7 +13,7 @@ Patterns for creating policy impact analyses, dashboards, and research using Pol
 
 See `MICROSIMULATION_REFORM_GUIDE.md` for UK-specific microsimulation patterns.
 
-## For Users 👥
+## For Users
 
 ### What are Analysis Repositories?
 
@@ -64,12 +64,12 @@ Analysis repositories produce the research you see on PolicyEngine:
 
 **See policyengine-writing-skill for writing conventions.**
 
-## For Analysts 📊
+## For Analysts
 
 ### When to Use This Skill
 
 - Creating policy impact analyses
-- Building interactive dashboards with Streamlit/Plotly
+- Building interactive dashboards with Next.js + Recharts
 - Writing analysis notebooks
 - Calculating distributional impacts
 - Comparing policy proposals
@@ -91,13 +91,10 @@ Standard analysis repository structure:
 ```
 analysis-repo/
 ├── analysis.ipynb           # Main Jupyter notebook
-├── app.py                   # Streamlit app (if applicable)
 ├── requirements.txt         # Python dependencies
 ├── README.md               # Documentation
 ├── data/                   # Data files (if needed)
-├── outputs/                # Generated charts, tables
-└── .streamlit/             # Streamlit config
-    └── config.toml
+└── outputs/                # Generated charts, tables
 ```
 
 ## Common Analysis Patterns
@@ -247,9 +244,9 @@ print(f"Neutral: {neutral.sum() / len(gains) * 100:.1f}%")
 import plotly.graph_objects as go
 
 # PolicyEngine brand colors
-TEAL = "#39C6C0"
-BLUE = "#2C6496"
-DARK_GRAY = "#616161"
+TEAL = "#319795"
+BLUE = "#026AA2"
+DARK_GRAY = "#5A5A5A"
 
 def create_pe_layout(title, xaxis_title, yaxis_title):
     """Create standard PolicyEngine chart layout."""
@@ -328,73 +325,6 @@ fig = go.Figure(go.Waterfall(
 ))
 ```
 
-## Streamlit Dashboard Patterns
-
-### Basic Streamlit Setup
-
-```python
-import streamlit as st
-from policyengine_us import Simulation
-
-st.set_page_config(page_title="Policy Analysis", layout="wide")
-
-st.title("Policy Impact Calculator")
-
-# User inputs
-col1, col2, col3 = st.columns(3)
-with col1:
-    income = st.number_input("Income", value=60000, step=5000)
-with col2:
-    state = st.selectbox("State", ["CA", "NY", "TX", "FL"])
-with col3:
-    num_children = st.number_input("Children", value=0, min_value=0, max_value=10)
-
-# Calculate
-if st.button("Calculate"):
-    situation = create_family(
-        parent_income=income,
-        num_children=num_children,
-        state=state
-    )
-
-    sim_baseline = Simulation(situation=situation)
-    sim_reform = Simulation(situation=situation, reform=reform)
-
-    # Display results
-    col1, col2, col3 = st.columns(3)
-    with col1:
-        st.metric(
-            "Baseline Tax",
-            f"${sim_baseline.calculate('income_tax', 2026)[0]:,.0f}"
-        )
-    with col2:
-        st.metric(
-            "Reform Tax",
-            f"${sim_reform.calculate('income_tax', 2026)[0]:,.0f}"
-        )
-    with col3:
-        change = (sim_reform.calculate('income_tax', 2026)[0] -
-                 sim_baseline.calculate('income_tax', 2026)[0])
-        st.metric("Change", f"${change:,.0f}", delta=f"${-change:,.0f}")
-```
-
-### Interactive Chart with Streamlit
-
-```python
-# Create chart based on user inputs
-incomes = np.linspace(0, income_max, 1001)
-results = []
-
-for income in incomes:
-    situation = create_situation(income=income, state=selected_state)
-    sim = Simulation(situation=situation, reform=reform)
-    results.append(sim.calculate("household_net_income", 2026)[0])
-
-fig = go.Figure()
-fig.add_trace(go.Scatter(x=incomes, y=results, line=dict(color=TEAL)))
-st.plotly_chart(fig, use_container_width=True)
-```
-
 ## Jupyter Notebook Best Practices
 
 ### Notebook Structure
@@ -449,7 +379,6 @@ pd.DataFrame([summary]).to_csv("outputs/summary.csv", index=False)
 This skill includes example templates in the `examples/` directory:
 
 - `impact_analysis_template.ipynb` - Standard impact analysis
-- `dashboard_template.py` - Streamlit dashboard
 - `state_comparison.py` - State-by-state analysis
 - `case_studies.py` - Household case studies
 - `reform_definitions.py` - Common reform patterns
@@ -555,7 +484,7 @@ Explanation of approach and data sources.
 ## How to Run
 
 \```bash
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 python app.py  # or jupyter notebook analysis.ipynb
 \```
 
@@ -571,5 +500,4 @@ PolicyEngine Team - hello@policyengine.org
 
 - **PolicyEngine API Docs:** https://policyengine.org/us/api
 - **Analysis Examples:** https://github.com/PolicyEngine/analysis-notebooks
-- **Streamlit Docs:** https://docs.streamlit.io
 - **Plotly Docs:** https://plotly.com/python/

--- a/skills/data-science/l0-skill/SKILL.md
+++ b/skills/data-science/l0-skill/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: l0
-description: L0 regularization for neural network sparsification and intelligent sampling - used in survey calibration
+description: |
+  L0 regularization for neural network sparsification and intelligent sampling - used in survey calibration.
+  Triggers: "L0", "sparsification", "sample selection", "hard concrete", "sparse weights", "household selection", "gate", "survey sparsity", "l0-python"
 ---
 
 # L0 Regularization
 
 L0 is a PyTorch implementation of L0 regularization for neural network sparsification and intelligent sampling, used in PolicyEngine's survey calibration pipeline.
 
-## For Users 👥
+## For Users
 
 ### What is L0?
 
@@ -21,7 +23,7 @@ L0 regularization helps PolicyEngine create more efficient survey datasets by in
 **Behind the scenes:**
 When PolicyEngine shows population-wide impacts, L0 helps select representative households from the full survey, reducing computation time while maintaining accuracy.
 
-## For Analysts 📊
+## For Analysts
 
 ### What L0 Does
 
@@ -38,7 +40,7 @@ L0 provides intelligent sampling gates for:
 ### Installation
 
 ```bash
-pip install l0-python
+uv pip install l0-python
 ```
 
 ### Quick Example: Sample Selection
@@ -70,7 +72,7 @@ gates = HardConcrete(
 # microcalibrate applies gates during weight optimization
 ```
 
-## For Contributors 💻
+## For Contributors
 
 ### Repository
 

--- a/skills/data-science/microcalibrate-skill/SKILL.md
+++ b/skills/data-science/microcalibrate-skill/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: microcalibrate
-description: Survey weight calibration to match population targets - used in policyengine-us-data for enhanced microdata
+description: |
+  Survey weight calibration to match population targets - used in policyengine-us-data for enhanced microdata.
+  Triggers: "calibrate", "calibration", "survey weights", "reweighting", "population targets", "benchmarks", "microcalibrate", "weight adjustment", "target matching"
 ---
 
 # MicroCalibrate
 
 MicroCalibrate calibrates survey weights to match population targets, with L0 regularization for sparsity and automatic hyperparameter tuning.
 
-## For Users 👥
+## For Users
 
 ### What is MicroCalibrate?
 
@@ -25,12 +27,12 @@ When you see PolicyEngine population impacts, the underlying data has been "cali
 - MicroCalibrate adjusts weights so survey totals match census totals
 - Result: More accurate PolicyEngine calculations
 
-## For Analysts 📊
+## For Analysts
 
 ### Installation
 
 ```bash
-pip install microcalibrate
+uv pip install microcalibrate
 ```
 
 ### What MicroCalibrate Does
@@ -160,7 +162,7 @@ Features:
 - View results
 - Download calibrated weights
 
-## For Contributors 💻
+## For Contributors
 
 ### Repository
 

--- a/skills/data-science/microdf-skill/SKILL.md
+++ b/skills/data-science/microdf-skill/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: microdf
-description: Weighted pandas DataFrames for survey microdata analysis - inequality, poverty, and distributional calculations
+description: |
+  Weighted pandas DataFrames for survey microdata analysis - inequality, poverty, and distributional calculations.
+  Triggers: "weighted mean", "Gini", "poverty rate", "inequality", "MicroDataFrame", "MicroSeries", "weighted statistics", "decile", "quintile", "income distribution", "microdf"
 ---
 
 # MicroDF
 
 MicroDF provides weighted pandas DataFrames and Series for analyzing survey microdata, with built-in support for inequality and poverty calculations.
 
-## For Users 👥
+## For Users
 
 ### What is MicroDF?
 
@@ -35,12 +37,12 @@ When you see poverty rates, Gini coefficients, or distributional charts in Polic
 - MicroDF calculates weighted percentiles
 - Shows income distribution (10th, 50th, 90th percentile)
 
-## For Analysts 📊
+## For Analysts
 
 ### Installation
 
 ```bash
-pip install microdf-python
+uv pip install microdf-python
 ```
 
 ### Quick Start
@@ -163,7 +165,7 @@ print(f"Gini: {gini:.3f}")
 print(f"Poverty rate: {poverty_rate:.1%}")
 ```
 
-## For Contributors 💻
+## For Contributors
 
 ### Repository
 

--- a/skills/data-science/microimpute-skill/SKILL.md
+++ b/skills/data-science/microimpute-skill/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: microimpute
-description: ML-based variable imputation for survey data - used in policyengine-us-data to fill missing values
+description: |
+  ML-based variable imputation for survey data - used in policyengine-us-data to fill missing values.
+  Triggers: "impute", "imputation", "missing values", "donor", "recipient", "quantile forest", "statistical matching", "PUF", "microimpute", "fill missing"
 ---
 
 # MicroImpute
 
 MicroImpute enables ML-based variable imputation through different statistical methods, with comparison and benchmarking capabilities.
 
-## For Users 👥
+## For Users
 
 ### What is MicroImpute?
 
@@ -30,15 +32,15 @@ When PolicyEngine calculates population impacts, the underlying survey data has 
 - Benefits eligibility uses complete household information
 - State-specific calculations have all needed data
 
-## For Analysts 📊
+## For Analysts
 
 ### Installation
 
 ```bash
-pip install microimpute
+uv pip install microimpute
 
 # With image export (for plots)
-pip install microimpute[images]
+uv pip install microimpute[images]
 ```
 
 ### What MicroImpute Does
@@ -119,7 +121,7 @@ print(results)
 # Compare across methods to choose best
 ```
 
-## For Contributors 💻
+## For Contributors
 
 ### Repository
 

--- a/skills/data-science/policyengine-uk-data-skill/SKILL.md
+++ b/skills/data-science/policyengine-uk-data-skill/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: policyengine-uk-data
-description: UK survey data enhancement - FRS with WAS imputation patterns
+description: |
+  UK survey data enhancement - FRS with WAS imputation patterns and cross-repo variable workflows.
+  Triggers: "FRS", "Family Resources Survey", "WAS", "Wealth and Assets Survey", "UK data", "UK microdata", "wealth imputation", "policyengine-uk-data"
 ---
 
 # PolicyEngine UK Data
@@ -49,12 +51,12 @@ policyengine_uk_data/
 
 **From PyPI:**
 ```bash
-pip install policyengine-uk-data
+uv pip install policyengine-uk-data
 ```
 
 **Development:**
 ```bash
-pip install -e .
+uv pip install -e .
 ```
 
 ## For Contributors

--- a/skills/data-science/policyengine-us-data-skill/SKILL.md
+++ b/skills/data-science/policyengine-us-data-skill/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: policyengine-us-data
-description: US survey data enhancement - CPS with PUF imputation patterns and cross-repo variable workflows
+description: |
+  US survey data enhancement - CPS with PUF imputation patterns and cross-repo variable workflows.
+  Triggers: "CPS", "Current Population Survey", "PUF", "Public Use File", "US data", "US microdata", "enhanced CPS", "policyengine-us-data", "cross-repo", "FINANCIAL_SUBSET"
 ---
 
 # PolicyEngine US Data
@@ -48,12 +50,12 @@ policyengine_us_data/
 
 **From PyPI:**
 ```bash
-pip install policyengine-us-data
+uv pip install policyengine-us-data
 ```
 
 **Development:**
 ```bash
-pip install -e .
+uv pip install -e .
 ```
 
 ## CRITICAL: Cross-Repo Variable Workflow
@@ -167,7 +169,7 @@ The CI uses whatever policyengine-us version satisfies the pyproject.toml constr
 ```
 ❌ Run microsim right after merging
    → Still using old cached data → Variable shows $0
-   → Need to wait for CI or `pip install --upgrade policyengine-us-data`
+   → Need to wait for CI or `uv pip install --upgrade policyengine-us-data`
 ```
 
 ### Checklist for New Data-Backed Variables
@@ -178,7 +180,7 @@ The CI uses whatever policyengine-us version satisfies the pyproject.toml constr
 - [ ] Create policyengine-us-data PR with:
   - [ ] Data extraction code in puf.py
   - [ ] Variable name in FINANCIAL_SUBSET (puf.py)
-  - [ ] Variable name in IMPUTED_VARIABLES (extended_cps.py) ⚠️ **Don't forget this!**
+  - [ ] Variable name in IMPUTED_VARIABLES (extended_cps.py) **Don't forget this!**
   - [ ] Bumped minimum policyengine-us version in pyproject.toml
   - [ ] Updated uv.lock via `uv lock`
 - [ ] Merge policyengine-us-data PR

--- a/skills/documentation/policyengine-design-skill/SKILL.md
+++ b/skills/documentation/policyengine-design-skill/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: policyengine-design
-description: PolicyEngine design system — tokens, typography, colors, charts, and branding for all project types
+description: |
+  PolicyEngine design system — tokens, typography, colors, charts, and branding for all project types.
+  Triggers: "brand colors", "design tokens", "PolicyEngine colors", "typography", "font", "color palette", "CSS variables", "pe-color", "design system", "branding guidelines"
 ---
 
 # PolicyEngine design system
 
-Single source of truth for PolicyEngine's visual identity. All tokens live in `@policyengine/design-system` (npm). Every project — app-v2, standalone tools, charts, Streamlit — should reference these values rather than hardcoding hex codes.
+Single source of truth for PolicyEngine's visual identity. All tokens live in `@policyengine/design-system` (npm). Every project — app-v2, standalone tools, charts — should reference these values rather than hardcoding hex codes.
 
 ## The design system package
 
 **Install:**
 ```bash
-npm install @policyengine/design-system
+bun install @policyengine/design-system
 ```
 
 **Three export formats:**
@@ -93,9 +95,9 @@ These appear in older projects. Migrate to the values above.
 
 | Old | Hex | Replacement |
 |-----|-----|-------------|
-| `TEAL_ACCENT` | `#39C6C0` | `primary.500` (`#319795`) |
-| `BLUE_PRIMARY` | `#2C6496` | `blue.700` (`#026AA2`) |
-| `DARK_GRAY` | `#616161` | `text.secondary` (`#5A5A5A`) |
+| `TEAL_ACCENT` | `#319795` | `primary.500` (`#319795`) |
+| `BLUE_PRIMARY` | `#026AA2` | `blue.700` (`#026AA2`) |
+| `DARK_GRAY` | `#5A5A5A` | `text.secondary` (`#5A5A5A`) |
 
 ## Typography
 
@@ -235,21 +237,6 @@ All logo files in `policyengine-app-v2/app/public/assets/logos/policyengine/`:
 https://raw.githubusercontent.com/PolicyEngine/policyengine-app-v2/main/app/public/assets/logos/policyengine/teal.png
 ```
 
-## Streamlit apps
-
-```toml
-# .streamlit/config.toml
-[theme]
-base = "light"
-primaryColor = "#319795"
-backgroundColor = "#FFFFFF"
-secondaryBackgroundColor = "#E6FFFA"
-textColor = "#000000"
-
-[client]
-toolbarMode = "minimal"
-```
-
 ## Using tokens by project type
 
 | Project type | Token source | Font setup |
@@ -257,7 +244,6 @@ toolbarMode = "minimal"
 | **app-v2** | `import { colors } from '@/designTokens'` | Built-in (Mantine + Inter) |
 | **Standalone tool** | `@import tokens.css` or CDN link | Google Fonts: Inter |
 | **Python chart** | Hardcode or load `tokens.json` | Inter for Plotly |
-| **Streamlit** | `.streamlit/config.toml` | Default sans-serif |
 | **Blog HTML** | Hardcode from token values | Google Fonts: Inter |
 
 ## Accessibility

--- a/skills/documentation/policyengine-research-lookup-skill/SKILL.md
+++ b/skills/documentation/policyengine-research-lookup-skill/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: policyengine-research-lookup
-description: Find and reference PolicyEngine blog posts, research articles, and published analyses for evidence and proof points
+description: |
+  Find and reference PolicyEngine blog posts, research articles, and published analyses for evidence and proof points.
+  Triggers: "find blog post", "PolicyEngine research", "published analysis", "proof point", "has PolicyEngine written about", "blog post about"
 ---
 
 # PolicyEngine Research Lookup
 
 Use this skill to find existing PolicyEngine research, blog posts, and published analyses that can serve as evidence, proof points, or references.
 
-## For Users 👥
+## For Users
 
 ### What is PolicyEngine Research?
 
@@ -29,7 +31,7 @@ PolicyEngine publishes research through:
 - Full UK tax-benefit system
 - Autumn Budget analyses, manifesto costing
 
-## For Analysts 📊
+## For Analysts
 
 ### Finding Blog Posts
 
@@ -78,7 +80,7 @@ tags:
 ---
 ```
 
-## For Contributors 💻
+## For Contributors
 
 ### When to Use This Skill
 

--- a/skills/documentation/policyengine-standards-skill/SKILL.md
+++ b/skills/documentation/policyengine-standards-skill/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: policyengine-standards
-description: PolicyEngine coding standards, formatters, CI requirements, and development best practices
+description: |
+  PolicyEngine coding standards, formatters, CI requirements, and development best practices.
+  Triggers: "CI failing", "linting", "formatting", "before committing", "PR standards", "code style", "black formatter", "prettier", "pre-commit"
 ---
 
 # PolicyEngine Standards Skill
@@ -113,245 +115,39 @@ done
 # Important: No timeout! Population simulations can take 30+ minutes.
 ```
 
-### DO NOT Say "I'll Check Back Later"
-
-**❌ WRONG:**
-```
-"I've created the PR as draft. CI checks will take a few minutes.
-I'll check back later once they complete."
-```
-
-**Why wrong:** You cannot check back later. The chat session ends.
-
-**✅ CORRECT:**
-```
-"I've created the PR as draft. Now polling CI status every 15 seconds..."
-[Actually polls using while loop]
-"CI checks completed. All passed! Marking PR as ready for review."
-```
-
-### When to Create Draft vs Ready
-
-**Always create as draft when:**
-- CI checks are configured
-- User asks to wait for CI
-- Making automated changes
-- Unsure if CI will pass
-
-**Create as ready only when:**
-- User explicitly requests ready PR
-- No CI configured
-- CI already verified locally
-
-### PR Workflow Standards
-
-**Standard flow:**
-```bash
-# 1. Ensure branch is pushed
-git push -u origin feature-branch
-
-# 2. Create PR as draft (use --repo for cross-fork PRs)
-gh pr create --repo PolicyEngine/policyengine-us --draft --title "..." --body "..."
-
-# 3. Wait for CI (use polling loop - see pattern above)
-
-# 4. If CI passes:
-gh pr ready $PR_NUMBER
-
-# 5. If CI fails:
-echo "CI failed. PR remains draft. Fix issues and push again."
-```
+**CRITICAL:** Never say "I'll check back later" — the chat session ends. Always use the polling loop above to actually wait. Default to creating PRs as draft; only create as ready when user explicitly requests it or CI is already verified.
 
 ## Test-Driven Development (TDD)
 
-PolicyEngine follows Test-Driven Development practices across all repositories.
+PolicyEngine follows TDD: write test first (RED), implement (GREEN), refactor. In multi-agent workflows, @test-creator and @rules-engineer work independently from the same regulations. See policyengine-core-skill for details.
 
-### TDD Workflow
-
-**1. Write test first (RED):**
-```python
-# tests/test_new_feature.py
-def test_california_eitc_calculation():
-    """Test California EITC for family with 2 children earning $30,000."""
-    situation = create_family(income=30000, num_children=2, state="CA")
-    sim = Simulation(situation=situation)
-    ca_eitc = sim.calculate("ca_eitc", 2026)[0]
-
-    # Test fails initially (feature not implemented yet)
-    assert ca_eitc == 3000, "CA EITC should be $3,000 for this household"
-```
-
-**2. Implement feature (GREEN):**
-```python
-# policyengine_us/variables/gov/states/ca/tax/income/credits/ca_eitc.py
-class ca_eitc(Variable):
-    value_type = float
-    entity = TaxUnit
-    definition_period = YEAR
-
-    def formula(tax_unit, period, parameters):
-        # Implementation to make test pass
-        federal_eitc = tax_unit("eitc", period)
-        return federal_eitc * parameters(period).gov.states.ca.tax.eitc.match
-```
-
-**3. Refactor (REFACTOR):**
-```python
-# Clean up, optimize, add documentation
-# All while tests continue to pass
-```
-
-### TDD Benefits
-
-**Why PolicyEngine uses TDD:**
-- ✅ **Accuracy** - Tests verify implementation matches regulations
-- ✅ **Documentation** - Tests show expected behavior
-- ✅ **Regression prevention** - Changes don't break existing features
-- ✅ **Confidence** - Safe to refactor
-- ✅ **Isolation** - Multi-agent workflow (test-creator and rules-engineer work separately)
-
-### TDD in Multi-Agent Workflow
-
-**Country model development:**
-1. **@document-collector** gathers regulations
-2. **@test-creator** writes tests from regulations (isolated, no implementation access)
-3. **@rules-engineer** implements from regulations (isolated, no test access)
-4. Both work from same source → tests verify implementation accuracy
-
-**See policyengine-core-skill and country-models agents for details.**
-
-### Test Examples
-
-**Python (pytest):**
+**Example test:**
 ```python
 def test_ctc_for_two_children():
     """Test CTC calculation for married couple with 2 children."""
-    situation = create_married_couple(
-        income_1=75000,
-        income_2=50000,
-        num_children=2,
-        child_ages=[5, 8]
-    )
-
+    situation = create_married_couple(income_1=75000, income_2=50000, num_children=2, child_ages=[5, 8])
     sim = Simulation(situation=situation)
     ctc = sim.calculate("ctc", 2026)[0]
-
     assert ctc == 4400, "CTC should be $2,200 per child"
-```
-
-**React (Jest + RTL):**
-```javascript
-import { render, screen } from '@testing-library/react';
-import TaxCalculator from './TaxCalculator';
-
-test('displays calculated tax', () => {
-  render(<TaxCalculator income={50000} />);
-
-  // Test what user sees, not implementation
-  expect(screen.getByText(/\$5,000/)).toBeInTheDocument();
-});
-```
-
-### Test Organization
-
-**Python:**
-```
-tests/
-├── test_variables/
-│   ├── test_income.py
-│   ├── test_deductions.py
-│   └── test_credits.py
-├── test_parameters/
-└── test_simulations/
-```
-
-**React:**
-```
-src/
-├── components/
-│   └── TaxCalculator/
-│       ├── TaxCalculator.jsx
-│       └── TaxCalculator.test.jsx
 ```
 
 ### Running Tests
 
-**Python:**
 ```bash
-# All tests
-make test
+# Python
+make test                    # All tests
+uv run pytest tests/ -v      # With uv
+uv run pytest tests/test_credits.py::test_ctc -v  # Specific test
 
-# With uv
-uv run pytest tests/ -v
-
-# Specific test
-uv run pytest tests/test_credits.py::test_ctc_for_two_children -v
-
-# With coverage
-uv run pytest tests/ --cov=policyengine_us --cov-report=html
+# React
+make test                    # All tests
+bun test -- --watch          # Watch mode
 ```
 
-**React:**
-```bash
-# All tests
-make test
+### Test quality
 
-# Watch mode
-npm test -- --watch
-
-# Specific test
-npm test -- TaxCalculator.test.jsx
-
-# Coverage
-npm test -- --coverage
-```
-
-### Test Quality Standards
-
-**Good tests:**
-- ✅ Test behavior, not implementation
-- ✅ Clear, descriptive names
-- ✅ Single assertion per test (when possible)
-- ✅ Include documentation (docstrings)
-- ✅ Based on official regulations with citations
-
-**Bad tests:**
-- ❌ Testing private methods
-- ❌ Mocking everything
-- ❌ No assertion messages
-- ❌ Magic numbers without explanation
-
-### Example: TDD for New Feature
-
-```python
-# Step 1: Write test (RED)
-def test_new_york_empire_state_child_credit():
-    """Test NY Empire State Child Credit for family with 1 child.
-
-    Based on NY Tax Law Section 606(c-1).
-    Family earning $50,000 with 1 child under 4 should receive $330.
-    """
-    situation = create_family(
-        income=50000,
-        num_children=1,
-        child_ages=[2],
-        state="NY"
-    )
-
-    sim = Simulation(situation=situation)
-    credit = sim.calculate("ny_empire_state_child_credit", 2026)[0]
-
-    assert credit == 330, "Should receive $330 for child under 4"
-
-# Test fails - feature doesn't exist yet
-
-# Step 2: Implement (GREEN)
-# Create variable in policyengine_us/variables/gov/states/ny/...
-# Test passes
-
-# Step 3: Refactor
-# Optimize, add documentation, maintain passing tests
-```
+- Test behavior, not implementation; clear names; docstrings with regulation citations
+- Avoid: testing private methods, mocking everything, magic numbers without explanation
 
 ## Python Standards
 
@@ -369,256 +165,89 @@ black . -l 79 --check
 ```
 
 ### Code Style
-```python
-# Imports: Grouped and alphabetized
-import os
-import sys
-from pathlib import Path  # stdlib
-
-import numpy as np
-import pandas as pd  # third-party
-
-from policyengine_us import Simulation  # local
-
-# Naming conventions
-class TaxCalculator:  # CamelCase for classes
-    pass
-
-def calculate_income_tax(income):  # snake_case for functions
-    annual_income = income * 12  # snake_case for variables
-    return annual_income
-
-# Type hints (recommended)
-def calculate_tax(income: float, state: str) -> float:
-    """Calculate state income tax.
-
-    Args:
-        income: Annual income in dollars
-        state: Two-letter state code
-
-    Returns:
-        Tax liability in dollars
-    """
-    pass
-
-# Error handling - catch specific exceptions
-try:
-    result = simulation.calculate("income_tax", 2026)
-except KeyError as e:
-    raise ValueError(f"Invalid variable name: {e}")
-```
-
-### Testing
-```python
-import pytest
-
-def test_ctc_calculation():
-    """Test Child Tax Credit calculation for family with 2 children."""
-    situation = create_family(income=50000, num_children=2)
-    sim = Simulation(situation=situation)
-    ctc = sim.calculate("ctc", 2026)[0]
-
-    assert ctc == 4400, "CTC should be $2200 per child"
-```
-
-**Run tests:**
-```bash
-# All tests
-make test
-
-# Or with uv
-uv run pytest tests/ -v
-
-# Specific test
-uv run pytest tests/test_tax.py::test_ctc_calculation -v
-
-# With coverage
-uv run pytest tests/ --cov=policyengine_us --cov-report=html
-```
+- **Imports**: Grouped (stdlib, third-party, local) and alphabetized
+- **Naming**: CamelCase for classes, snake_case for functions/variables
+- **Type hints**: Recommended, especially for public APIs
+- **Docstrings**: Required for public functions/classes (Google style)
+- **Error handling**: Catch specific exceptions, not bare `except`
 
 ## JavaScript/React Standards
 
 ### Formatting
 - **Formatters**: Prettier + ESLint
-- **Command**: `npm run lint -- --fix && npx prettier --write .`
-- **CI Check**: `npm run lint -- --max-warnings=0`
+- **Command**: `bun run lint -- --fix && bunx prettier --write .`
+- **CI Check**: `bun run lint -- --max-warnings=0`
 
 ```bash
 # Format all files
 make format
 
 # Or manually
-npm run lint -- --fix
-npx prettier --write .
+bun run lint -- --fix
+bunx prettier --write .
 
 # Check if formatting is needed (CI-style)
-npm run lint -- --max-warnings=0
+bun run lint -- --max-warnings=0
 ```
 
 ### Code Style
-```javascript
-// Use functional components only (no class components)
-import { useState, useEffect } from "react";
-
-function TaxCalculator({ income, state }) {
-  const [tax, setTax] = useState(0);
-
-  useEffect(() => {
-    // Calculate tax when inputs change
-    calculateTax(income, state).then(setTax);
-  }, [income, state]);
-
-  return (
-    <div>
-      <p>Tax: ${tax.toLocaleString()}</p>
-    </div>
-  );
-}
-
-// File naming
-// - Components: PascalCase.jsx (TaxCalculator.jsx)
-// - Utilities: camelCase.js (formatCurrency.js)
-
-// Environment config - use config file pattern
-// src/config/environment.js
-const config = {
-  API_URL: process.env.NODE_ENV === 'production'
-    ? 'https://api.policyengine.org'
-    : 'http://localhost:5000'
-};
-export default config;
-```
-
-### React Component Size
-- Keep components under 150 lines after formatting
-- Extract complex logic into custom hooks
-- Split large components into smaller ones
+- Functional components only (no class components), hooks for state
+- File naming: PascalCase.jsx for components, camelCase.js for utilities
+- Use `src/config/environment.js` pattern for env config (not REACT_APP_ env vars)
+- Keep components under 150 lines; extract complex logic into custom hooks
 
 ## Version Control Standards
 
 ### Changelog Management
 
-**CRITICAL**: For PRs, ONLY modify `changelog_entry.yaml`. NEVER manually update `CHANGELOG.md` or `changelog.yaml`.
+**CRITICAL**: NEVER manually update `CHANGELOG.md`. Check which system the repo uses, then follow that system.
 
-**Terminology Note:**
-When someone says "add a changelog entry" or "needs a changelog entry" in PolicyEngine context, they mean:
-- ✅ Create/update `changelog_entry.yaml` (the PR-level entry file)
-- ❌ NOT editing `CHANGELOG.md` (the main changelog file)
-- ❌ NOT editing `changelog.yaml` (the compiled changelog)
+**How to tell which system a repo uses:**
+1. Check if the repo has a `changelog.d/` directory -- if yes, use **towncrier** (new system)
+2. If no `changelog.d/` but the repo uses `changelog_entry.yaml`, use the **legacy system**
 
-**Correct Workflow:**
-1. Create `changelog_entry.yaml` at repository root:
-   ```yaml
-   - bump: patch  # or minor, major
-     changes:
-       added:
-       - Description of new feature
-       fixed:
-       - Description of bug fix
-       changed:
-       - Description of change
-   ```
+#### New system: towncrier (`changelog.d/` fragments)
 
-2. Commit ONLY `changelog_entry.yaml` with your code changes
+Used by: policyengine-claude, and newer repos with a `changelog.d/` directory.
 
-3. GitHub Actions automatically updates `CHANGELOG.md` and `changelog.yaml` on merge
-
-**DO NOT:**
-- ❌ Run `make changelog` manually during PR creation
-- ❌ Commit `CHANGELOG.md` or `changelog.yaml` in your PR
-- ❌ Modify main changelog files directly
-
-### Git Workflow
-
-1. **Create branches on PolicyEngine repos, NOT forks**
-   - Forks cause CI failures due to missing secrets
-   - Request write access if needed
-
-2. **Branch naming**: `feature-name` or `fix-issue-123`
-
-3. **Commit messages**:
-   ```
-   Add CTC reform analysis for CRFB report
-
-   - Implement household-level calculations
-   - Add state-by-state comparison
-   - Create visualizations
-
-   Fixes #123
-   ```
-
-4. **PR description**: Include "Fixes #123" to auto-close issues
-
-### Common Git Pitfalls
-
-**Never do these:**
-- ❌ Force push to main/master
-- ❌ Commit secrets or `.env` files
-- ❌ Skip hooks with `--no-verify`
-- ❌ Create versioned files (app_v2.py, component_new.jsx)
-
-**Always do:**
-- ✅ Fix original files in place
-- ✅ Run formatters before pushing
-- ✅ Reference issue numbers in commits
-- ✅ Watch CI after filing PR
-
-## Common AI Pitfalls
-
-Since many PRs are AI-generated, watch for these common mistakes:
-
-### 1. File Versioning
-**❌ Wrong:**
 ```bash
-# Creating new versions instead of fixing originals
-app_new.py
-app_v2.py
-component_refactored.jsx
+echo "Description of change." > changelog.d/branch-name.added.md
 ```
 
-**✅ Correct:**
-```bash
-# Always modify the original file
-app.py  # Fixed in place
+Fragment filename format: `{name}.{type}.md`
+Types: `added` (minor), `changed` (patch), `fixed` (patch), `removed` (minor), `breaking` (major)
+
+GitHub Actions runs `towncrier build` on merge to compile fragments into CHANGELOG.md.
+
+#### Legacy system: `changelog_entry.yaml`
+
+Used by: policyengine-us, policyengine-uk, and other country model repos.
+
+Create `changelog_entry.yaml` at repository root:
+```yaml
+- bump: patch  # or minor, major
+  changes:
+    added:
+    - Description of new feature
+    fixed:
+    - Description of bug fix
 ```
 
-### 2. Formatter Not Run
-**❌ Wrong:** Committing without formatting (main cause of CI failures)
+GitHub Actions automatically updates `CHANGELOG.md` and `changelog.yaml` on merge.
 
-**✅ Correct:**
-```bash
-# Python
-make format
-black . -l 79
+**DO NOT (either system):**
+- Run `make changelog` manually during PR creation
+- Commit `CHANGELOG.md` in your PR
+- Modify main changelog files directly
 
-# React
-npm run lint -- --fix
-npx prettier --write .
-```
+### Git workflow and common pitfalls
 
-### 3. Environment Variables
-**❌ Wrong:**
-```javascript
-// React env vars without REACT_APP_ prefix
-const API_URL = process.env.API_URL;  // Won't work!
-```
+See the parent `PolicyEngine/CLAUDE.md` for full git workflow, branch naming, commit message format, and common AI pitfalls (file versioning, formatter not run, env vars, wrong Python version). Key points:
 
-**✅ Correct:**
-```javascript
-// Use config file pattern instead
-import config from './config/environment';
-const API_URL = config.API_URL;
-```
-
-### 4. Using Wrong Python Version
-**❌ Wrong:** Downgrading to Python 3.10 or older
-
-**✅ Correct:** Use Python 3.13 as specified in project requirements
-
-### 5. Manual Changelog Updates
-**❌ Wrong:** Running `make changelog` and committing `CHANGELOG.md`
-
-**✅ Correct:** Only create `changelog_entry.yaml` in PR
+- Create branches on PolicyEngine repos, NOT forks (forks fail CI)
+- Always run `make format` before committing
+- Never create versioned files (app_v2.py, component_new.jsx)
+- Include "Fixes #123" in PR descriptions
 
 ## Repository Setup Patterns
 
@@ -669,25 +298,9 @@ make debug      # Start dev server (apps)
 make build      # Production build (apps)
 ```
 
-## CI Stability
+## CI stability
 
-### Common CI Issues
-
-**1. Fork PRs Fail**
-- **Problem**: PRs from forks don't have access to repository secrets
-- **Solution**: Create branches directly on PolicyEngine repos
-
-**2. GitHub API Rate Limits**
-- **Problem**: Smoke tests fail with 403 errors
-- **Solution**: Re-run failed jobs (different runners have different limits)
-
-**3. Linting Failures**
-- **Problem**: Code not formatted before commit
-- **Solution**: Always run `make format` before committing
-
-**4. Test Failures in CI but Pass Locally**
-- **Problem**: Missing `uv run` prefix
-- **Solution**: Use `uv run pytest` instead of `pytest`
+See `PolicyEngine/CLAUDE.md` for full CI stability details (fork failures, rate limits, linting). Quick fixes: use `make format` before committing, use `uv run pytest` not bare `pytest`, create branches on PolicyEngine repos not forks.
 
 ## Repo rename checklist
 
@@ -734,75 +347,6 @@ If the renamed repo is embedded in another site (e.g., via iframe or GitHub Page
   ```
 - Update any external references (blog posts on policyengine.org, Notion docs, etc.) that link to the old GitHub Pages URL.
 
-## Best Practices Checklist
-
-### Code Quality
-- [ ] Code formatted with Black (Python) or Prettier (JS)
-- [ ] No linting errors
-- [ ] All tests pass
-- [ ] Type hints added (Python, where applicable)
-- [ ] Docstrings for public functions/classes
-- [ ] Error handling with specific exceptions
-
-### Version Control
-- [ ] Only `changelog_entry.yaml` created (not CHANGELOG.md)
-- [ ] Commit message references issue number
-- [ ] Branch created on PolicyEngine repo (not fork)
-- [ ] No secrets or .env files committed
-- [ ] Original files modified (no _v2 or _new files)
-
-### Testing
-- [ ] Tests written for new functionality
-- [ ] Tests pass locally with `make test`
-- [ ] Coverage maintained or improved
-- [ ] Edge cases handled
-
-### Documentation
-- [ ] README updated if needed
-- [ ] Code comments for complex logic
-- [ ] API documentation updated if needed
-- [ ] Examples provided for new features
-
-## Quick Reference
-
-### Format Commands by Language
-
-**Python:**
-```bash
-make format                # Format code
-black . -l 79 --check      # Check formatting
-uv run pytest tests/ -v    # Run tests
-```
-
-**React:**
-```bash
-make format                              # Format code
-npm run lint -- --max-warnings=0         # Check linting
-npm test                                 # Run tests
-```
-
-### Pre-Commit Checklist
-```bash
-# 1. Format
-make format
-
-# 2. Test
-make test
-
-# 3. Check linting
-# Python: black . -l 79 --check
-# React: npm run lint -- --max-warnings=0
-
-# 4. Stage and commit
-git add .
-git commit -m "Description
-
-Fixes #123"
-
-# 5. Push and watch CI
-git push
-```
-
 ## Resources
 
 - **Main CLAUDE.md**: `/PolicyEngine/CLAUDE.md`
@@ -816,5 +360,4 @@ git push
 See PolicyEngine repositories for examples of standard-compliant code:
 - **policyengine-us**: Python package standards
 - **policyengine-app**: React app standards
-- **givecalc**: Streamlit app standards
 - **crfb-tob-impacts**: Analysis repository standards

--- a/skills/documentation/policyengine-user-guide-skill/SKILL.md
+++ b/skills/documentation/policyengine-user-guide-skill/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: policyengine-user-guide
-description: Using PolicyEngine web apps to analyze tax and benefit policy impacts - for users of policyengine.org
+description: |
+  Using PolicyEngine web apps to analyze tax and benefit policy impacts - for users of policyengine.org.
+  Triggers: "how to use PolicyEngine", "household calculator", "policy reform on website", "policyengine.org walkthrough", "web app guide"
 ---
 
 # PolicyEngine User Guide

--- a/skills/documentation/policyengine-writing-skill/SKILL.md
+++ b/skills/documentation/policyengine-writing-skill/SKILL.md
@@ -622,7 +622,7 @@ Should work great once merged!
 Install PolicyEngine-US from PyPI:
 
 ```bash
-pip install policyengine-us
+uv pip install policyengine-us
 ```
 
 This installs version 1.103.0 or later, which includes support for 2025
@@ -636,7 +636,7 @@ tax parameters.
 Simply install PolicyEngine-US:
 
 ```bash
-pip install policyengine-us
+uv pip install policyengine-us
 ```
 
 This will install the latest version with all the newest features!

--- a/skills/domain-knowledge/policyengine-healthcare-skill/SKILL.md
+++ b/skills/domain-knowledge/policyengine-healthcare-skill/SKILL.md
@@ -481,7 +481,7 @@ parameters/gov/aca/
 │   ├── default.yaml                    # Federal 3:1 ratio
 │   ├── al.yaml, dc.yaml, ...          # 7 states with custom curves
 │   └── ny.yaml, vt.yaml               # Family tier states
-├── required_contribution_percentage/   # ⚠️ LIST-VALUED — not scalar!
+├── required_contribution_percentage/   # LIST-VALUED — not scalar!
 │   ├── threshold.yaml                  # FPL bracket boundaries (list)
 │   ├── initial.yaml                    # Initial contribution rates by bracket (list)
 │   └── final.yaml                      # Final contribution rates by bracket (list)

--- a/skills/domain-knowledge/policyengine-uk-skill/SKILL.md
+++ b/skills/domain-knowledge/policyengine-uk-skill/SKILL.md
@@ -82,7 +82,7 @@ PolicyEngine-UK is the "calculator" for UK taxes and benefits. When you use poli
 ### Installation
 
 ```bash
-pip install policyengine
+uv pip install policyengine
 ```
 
 ### Two Modes of Analysis

--- a/skills/domain-knowledge/policyengine-us-skill/SKILL.md
+++ b/skills/domain-knowledge/policyengine-us-skill/SKILL.md
@@ -75,7 +75,7 @@ PolicyEngine-US is the "calculator" for US taxes and benefits. When you use poli
 ### Installation
 
 ```bash
-pip install policyengine
+uv pip install policyengine
 ```
 
 ### Two Modes of Analysis

--- a/skills/technical-patterns/policyengine-data-testing-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-data-testing-skill/SKILL.md
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install -e .
+        run: uv pip install -e .
       - name: Run tests
         run: make test
 ```
@@ -331,8 +331,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e .
-          pip install pytest pytest-cov
+          uv pip install -e .
+          uv pip install pytest pytest-cov
 
       - name: Run data pipeline tests
         run: |

--- a/skills/technical-patterns/policyengine-recharts-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-recharts-skill/SKILL.md
@@ -17,7 +17,7 @@ Use this skill when creating or modifying charts in PolicyEngine applications. P
 ## Installation
 
 ```bash
-npm install recharts
+bun install recharts
 ```
 
 Do NOT install `plotly.js` or `react-plotly.js` for new projects.

--- a/skills/tools-and-apis/policyengine-api-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-api-skill/SKILL.md
@@ -7,7 +7,7 @@ description: PolicyEngine API - Flask REST service powering policyengine.org and
 
 The PolicyEngine API is a Flask-based REST service that provides tax and benefit calculations for the web app and programmatic users.
 
-## For Users 👥
+## For Users
 
 ### What is the API?
 
@@ -38,7 +38,7 @@ curl https://api.policyengine.org/us/policy/2
 
 **Interactive docs:** Swagger UI at API docs endpoint
 
-## For Analysts 📊
+## For Analysts
 
 ### Using the API
 
@@ -106,7 +106,7 @@ GET /us/variable/{variable_name}
 - Batch calculations when possible
 - Use webhooks for long-running jobs (population impacts)
 
-## For Contributors 💻
+## For Contributors
 
 ### Repository
 

--- a/skills/tools-and-apis/policyengine-api-v2-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-api-v2-skill/SKILL.md
@@ -7,7 +7,7 @@ description: PolicyEngine API v2 - Next-generation microservices architecture wi
 
 The next-generation PolicyEngine API is a monorepo containing multiple microservices built with modern Python tooling.
 
-## For Users 👥
+## For Users
 
 ### What is API v2?
 
@@ -22,7 +22,7 @@ API v2 is the next generation of the PolicyEngine API, currently in active devel
 - Auto-generated OpenAPI specs and clients
 - Supabase for database management
 
-## For Analysts 📊
+## For Analysts
 
 ### When to Use v2
 
@@ -30,7 +30,7 @@ Currently, analysts should continue using the v1 API at `https://api.policyengin
 
 API v2 is not yet ready for production use. Check the repository README for the latest status.
 
-## For Contributors 💻
+## For Contributors
 
 ### Repository
 
@@ -185,7 +185,7 @@ cat package.json | grep -A 5 "dependencies"
 **If using npm design tokens:**
 ```bash
 # Design tokens from app-v2
-npm install @policyengine/design-tokens
+bun install @policyengine/design-tokens
 ```
 
 ### OpenAPI Specification

--- a/skills/tools-and-apis/policyengine-core-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-core-skill/SKILL.md
@@ -7,7 +7,7 @@ description: PolicyEngine Core simulation engine - the foundation powering all P
 
 PolicyEngine Core is the microsimulation engine that powers all PolicyEngine calculations. It's a fork of OpenFisca-Core adapted for PolicyEngine's needs.
 
-## For Users 👥
+## For Users
 
 ### What is Core?
 
@@ -32,7 +32,7 @@ Core ensures:
 - ✅ **Transparency** - All rules traceable to legislation
 - ✅ **Performance** - Vectorized calculations for speed
 
-## For Analysts 📊
+## For Analysts
 
 ### Understanding Core Concepts
 
@@ -109,7 +109,7 @@ policyengine-api (REST API)
 policyengine-app (web interface)
 ```
 
-## For Contributors 💻
+## For Contributors
 
 ### Repository
 
@@ -287,7 +287,7 @@ pytest tests/core/test_variables.py -v
 ```bash
 # Changes to Core affect all country packages
 cd policyengine-us
-pip install -e ../policyengine-core  # Local development install
+uv pip install -e ../policyengine-core  # Local development install
 make test
 ```
 
@@ -331,7 +331,7 @@ git log --oneline
 5. **Test in country package:**
    ```bash
    cd ../policyengine-us
-   pip install -e ../policyengine-core
+   uv pip install -e ../policyengine-core
    make test
    ```
 

--- a/skills/tools-and-apis/policyengine-github-agent-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-github-agent-skill/SKILL.md
@@ -5,11 +5,11 @@ description: Guidance for working with the PolicyEngine GitHub agent bot
 
 # PolicyEngine GitHub Agent Skill
 
-## For Users 👥
+## For Users
 
 The PolicyEngine GitHub agent is an automated bot that can be invoked on GitHub issues and pull requests using `@policyengine` mentions. It helps with code reviews, bug fixes, and implementing features across PolicyEngine repositories.
 
-## For Contributors 💻
+## For Contributors
 
 ### Critical: Avoiding Doom Loops
 

--- a/skills/tools-and-apis/policyengine-python-client-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-python-client-skill/SKILL.md
@@ -17,10 +17,10 @@ This skill covers programmatic access to PolicyEngine for analysts and researche
 
 ```bash
 # Install the Python client
-pip install policyengine
+uv pip install policyengine
 
 # Or for local development
-pip install policyengine-us  # Just the US model (offline)
+uv pip install policyengine-us  # Just the US model (offline)
 ```
 
 ## Quick Start: Python Client
@@ -111,7 +111,7 @@ from policyengine import Simulation
 
 # Define reform (increase CTC to $5,000)
 reform = {
-    "gov.irs.credits.ctc.amount.base_amount": {
+    "gov.irs.credits.ctc.amount.base[0].amount": {
         "2026-01-01.2100-12-31": 5000
     }
 }
@@ -199,7 +199,7 @@ policy = response.json()
 ```python
 # Get current parameter value
 response = requests.get(
-    "https://api.policyengine.org/us/parameter/gov.irs.credits.ctc.amount.base_amount"
+    "https://api.policyengine.org/us/parameter/gov.irs.credits.ctc.amount.base"
 )
 parameter = response.json()
 ```
@@ -262,8 +262,8 @@ curl -X POST https://api.policyengine.org/us/calculate \
 
 **Install:**
 ```bash
-pip install policyengine-us  # US only
-pip install policyengine-uk  # UK only
+uv pip install policyengine-us  # US only
+uv pip install policyengine-uk  # UK only
 ```
 
 **Example:**


### PR DESCRIPTION
## Summary

Systematic audit of all 41 skills across the policyengine-claude plugin, identifying 23 critical, ~70 medium, and ~44 low-priority issues. This PR fixes the critical and medium issues across 22 files.

### Critical fixes
- **pip -> uv pip** across 14 skills (org standard per CLAUDE.md)
- **Remove all Streamlit references** from 3 skills (design, analysis, standards) — Streamlit is banned per global CLAUDE.md
- **Fix deprecated brand colors** in analysis skill
- **Fix wrong CTC parameter path** (base_amount -> base[0].amount) in python-client skill
- **Fix changelog documentation** in standards skill — now documents both towncrier and legacy systems
- **Trim standards skill** from 820 -> 363 lines — removed massive duplication with PolicyEngine/CLAUDE.md

### Medium fixes
- **npm -> bun** in 4 skills (design, standards, recharts, api-v2)
- **Add trigger phrases** to 10 skills that had terse single-line descriptions
- **Remove emoji** from section headers in 12 skills

### Remaining work (future PRs)
- 12 skills still over 500-line limit — splitting needed
- Healthcare skill needs migration to new policyengine wrapper API
- Unverified API examples in l0, microcalibrate, microimpute skills

## Test plan
- [ ] Plugin loads without errors
- [ ] Skill descriptions render correctly
- [ ] Spot-check skills for content accuracy
