### PR TITLE
Replace hardcoded hex colors with design system token references

### DIFF
--- a/changelog.d/design-token-colors.changed.md
+++ b/changelog.d/design-token-colors.changed.md
@@ -1,0 +1,1 @@
+Replace hardcoded hex colors with design system token references across chart and content skills.

--- a/skills/analysis/policyengine-analysis-skill/SKILL.md
+++ b/skills/analysis/policyengine-analysis-skill/SKILL.md
@@ -243,10 +243,11 @@ print(f"Neutral: {neutral.sum() / len(gains) * 100:.1f}%")
 ```python
 import plotly.graph_objects as go
 
-# PolicyEngine brand colors
-TEAL = "#319795"
-BLUE = "#026AA2"
-DARK_GRAY = "#5A5A5A"
+# PolicyEngine brand colors — see policyengine-design-skill for canonical values.
+# Python charts can't use CSS vars, so reference the design token hex values:
+TEAL = "#319795"       # --pe-color-primary-500
+BLUE = "#026AA2"       # --pe-color-blue-700
+DARK_GRAY = "#5A5A5A"  # --pe-color-text-secondary
 
 def create_pe_layout(title, xaxis_title, yaxis_title):
     """Create standard PolicyEngine chart layout."""

--- a/skills/content/content-generation-skill/SKILL.md
+++ b/skills/content/content-generation-skill/SKILL.md
@@ -16,7 +16,7 @@ This skill provides templates and patterns for generating consistent, branded Po
 ### Social media images
 
 1200x630 PNG images for LinkedIn, X (Twitter), and Facebook with:
-- PolicyEngine brand colors (teal #319795, dark background #1a2332)
+- PolicyEngine brand colors from design tokens (teal primary, dark background)
 - Inter font family
 - Headline with teal highlight
 - Optional headshot with quote
@@ -73,11 +73,17 @@ logo_path: Path to PolicyEngine logo
 ## Brand guidelines
 
 ### Colors
-- Primary teal: #319795
-- Light teal: #5EEAD4
-- Dark background: #1a2332 / #0F172A
-- Text gray: #94A3B8
-- White: #FFFFFF
+
+Source of truth: `policyengine-design-skill` and `@policyengine/design-system` CSS tokens.
+Social image generation runs in headless Chrome with design tokens loaded, so use CSS vars where possible. Fallback hex values for non-browser contexts:
+
+| Token | CSS var | Hex |
+|-------|---------|-----|
+| Primary teal | `--pe-color-primary-500` | #319795 |
+| Light teal | `--pe-color-primary-200` | #81E6D9 |
+| Dark background | (custom) | #1a2332 |
+| Text gray | `--pe-color-gray-400` | #9CA3AF |
+| White | `--pe-color-bg-primary` | #FFFFFF |
 
 ### Typography
 - Font family: Inter (Google Fonts)

--- a/skills/documentation/policyengine-design-skill/SKILL.md
+++ b/skills/documentation/policyengine-design-skill/SKILL.md
@@ -7,7 +7,19 @@ description: |
 
 # PolicyEngine design system
 
-Single source of truth for PolicyEngine's visual identity. All tokens live in `@policyengine/design-system` (npm). Every project — app-v2, standalone tools, charts — should reference these values rather than hardcoding hex codes.
+Single source of truth for PolicyEngine's visual identity. All tokens live in `@policyengine/design-system`. Every project — app-v2, standalone tools, charts — should reference these tokens, never hardcode hex values.
+
+**When to use which format:**
+
+| Context | Approach | Example |
+|---------|----------|---------|
+| **React/Next.js components** | CSS vars or TS imports | `style={{ color: "var(--pe-color-primary-500)" }}` or `colors.primary[500]` |
+| **Recharts (SVG)** | Resolve CSS vars at render time via `getCssVar()` | `const teal = getCssVar("--pe-color-primary-500")` |
+| **Tailwind** | Use `theme.extend.colors` mapped to CSS vars | `className="text-pe-primary-500"` |
+| **Python charts (Plotly/matplotlib)** | Hex values with CSS var name in comment | `TEAL = "#319795"  # --pe-color-primary-500` |
+| **`<meta>` tags, static HTML** | Hex values with CSS var name in comment | `content="#319795"` |
+
+Python has no CSS runtime, so hex values are acceptable — but always comment with the CSS var name so values stay traceable to the design system.
 
 ## The design system package
 

--- a/skills/technical-patterns/policyengine-recharts-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-recharts-skill/SKILL.md
@@ -100,11 +100,15 @@ Recharts default tooltip separator is ` : ` (with leading space). Always set `se
 
 ## Standard chart template
 
+Recharts renders to SVG, which cannot read CSS custom properties. Resolve design tokens at render time with a helper (see `policyengine-interactive-tools-skill` for the `getCssVar` utility):
+
 ```tsx
+import { useMemo } from "react";
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid,
   Tooltip, ResponsiveContainer, Label, ReferenceDot,
 } from "recharts";
+import getCssVar from "@/lib/getCssVar"; // reads CSS custom properties
 
 interface DataPoint { x: number; y: number; }
 
@@ -112,6 +116,14 @@ export default function MyChart({ data, highlightX }: {
   data: DataPoint[];
   highlightX?: number;
 }) {
+  // Resolve design tokens for SVG (never hardcode hex values)
+  const { primaryColor, darkTeal, gridColor, fontFamily } = useMemo(() => ({
+    primaryColor: getCssVar("--pe-color-primary-500"),
+    darkTeal:     getCssVar("--pe-color-primary-900"),
+    gridColor:    getCssVar("--pe-color-gray-200"),
+    fontFamily:   getCssVar("--pe-font-family-primary") || "Inter, sans-serif",
+  }), []);
+
   const fmt = (v: number) => v.toLocaleString("en-US", {
     style: "currency", currency: "USD", maximumFractionDigits: 0,
   });
@@ -129,27 +141,27 @@ export default function MyChart({ data, highlightX }: {
   return (
     <ResponsiveContainer width="100%" height={350}>
       <LineChart data={data} margin={{ left: 20, right: 30, top: 10, bottom: 20 }}>
-        <CartesianGrid stroke="#E2E8F0" strokeDasharray="3 3" />
+        <CartesianGrid stroke={gridColor} strokeDasharray="3 3" />
         <XAxis
           dataKey="x" type="number"
           domain={[0, xTicks[xTicks.length - 1]]} ticks={xTicks}
           tickFormatter={fmt}
-          tick={{ fontFamily: "Inter, sans-serif", fontSize: 12 }}
+          tick={{ fontFamily, fontSize: 12 }}
         >
           <Label value="X axis" position="bottom" offset={0} />
         </XAxis>
         <YAxis
           domain={[0, yTicks[yTicks.length - 1]]} ticks={yTicks}
           tickFormatter={fmt}
-          tick={{ fontFamily: "Inter, sans-serif", fontSize: 12 }}
+          tick={{ fontFamily, fontSize: 12 }}
         >
           <Label value="Y axis" angle={-90} position="insideLeft" offset={-5} />
         </YAxis>
         <Tooltip separator=": " formatter={(v: number) => [fmt(v), "Value"]} />
-        <Line type="monotone" dataKey="y" stroke="#319795" strokeWidth={3} dot={false} />
+        <Line type="monotone" dataKey="y" stroke={primaryColor} strokeWidth={3} dot={false} />
         {highlightPoint && (
           <ReferenceDot x={highlightPoint.x} y={highlightPoint.y} r={6}
-            fill="#1D4044" stroke="#1D4044" />
+            fill={darkTeal} stroke={darkTeal} />
         )}
       </LineChart>
     </ResponsiveContainer>
@@ -170,28 +182,28 @@ export default function MyChart({ data, highlightX }: {
 
 ## PolicyEngine styling
 
-```typescript
-// Colors (from @policyengine/design-system or hardcoded)
-const TEAL_PRIMARY = "#319795";   // Primary series
-const DARK_TEAL = "#1D4044";     // Reference dots
-const GRID_COLOR = "#E2E8F0";    // Grid lines
-const TEAL_LIGHT = "rgba(49, 151, 149, 0.15)";  // Light fill
-const TEAL_MEDIUM = "rgba(49, 151, 149, 0.35)"; // Medium fill
+Never hardcode hex colors in frontend chart code. Resolve from CSS custom properties at render time:
 
-// Font
-const CHART_FONT = {
-  fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-  fontSize: 12,
-};
+```typescript
+import getCssVar from "@/lib/getCssVar";
+
+// Resolve design tokens once per render (useMemo in components)
+const primaryColor = getCssVar("--pe-color-primary-500");    // Primary series
+const darkTeal     = getCssVar("--pe-color-primary-900");    // Reference dots
+const gridColor    = getCssVar("--pe-color-gray-200");       // Grid lines
+const lightFill    = getCssVar("--pe-color-primary-alpha-40"); // Light fill
+const fontFamily   = getCssVar("--pe-font-family-primary");  // Font
 
 // Tooltip
 const TOOLTIP_STYLE = {
-  background: "#fff",
-  border: "1px solid #E2E8F0",
+  background: "var(--pe-color-bg-primary)",
+  border: "1px solid var(--pe-color-border-light)",
   borderRadius: 6,
   padding: "8px 12px",
 };
 ```
+
+See `policyengine-design-skill` for the full token reference. The `getCssVar` helper is documented in `policyengine-interactive-tools-skill`.
 
 ## Key rules
 
@@ -202,7 +214,7 @@ const TOOLTIP_STYLE = {
 5. **Always wrap in `ResponsiveContainer`** with explicit height
 6. **Use `dot={false}`** on Line components for clean curves with many data points
 7. **Use `ReferenceDot`** to highlight the user's current selection
-8. **Teal (#319795) is the primary chart color** - matches PolicyEngine brand
+8. **Use design tokens for chart colors** — resolve `--pe-color-primary-500` (teal) via `getCssVar`, never hardcode hex values
 9. **Negative currency: sign before symbol** - Always format as `-$31`, never `$-31`
 
 ## Currency formatting

--- a/skills/technical-patterns/seo-checklist-skill/SKILL.md
+++ b/skills/technical-patterns/seo-checklist-skill/SKILL.md
@@ -166,7 +166,7 @@ Every PolicyEngine web app needs these in `index.html`:
 }
 </script>
 
-<!-- Theme color for mobile browsers -->
+<!-- Theme color for mobile browsers — use --pe-color-primary-500 value -->
 <meta name="theme-color" content="#319795">
 ```
 


### PR DESCRIPTION
## Summary

Replaces hardcoded hex color values across 5 skills with design system token references.

- **Recharts skill**: Chart template now uses `getCssVar("--pe-color-primary-500")` instead of `"#319795"` literals. Styling section updated to show token-based approach.
- **Analysis skill**: Python chart colors now comment the CSS var name for traceability (hex values kept since Python has no CSS runtime).
- **Content generation skill**: Brand color list now shows both CSS var names and hex fallbacks in a table.
- **Design skill**: Added "when to use which format" table — CSS vars for frontend, hex-with-comment for Python, `getCssVar()` for Recharts SVG.
- **SEO checklist skill**: Theme-color meta tag now comments the token name.

## Test plan
- [ ] Plugin loads without errors
- [ ] Recharts skill template compiles (references getCssVar pattern from interactive-tools skill)
