### PR TITLE
Improve user checkpoints with structured AskUserQuestion

### DIFF
--- a/changelog.d/improve-user-checkpoints.changed.md
+++ b/changelog.d/improve-user-checkpoints.changed.md
@@ -1,0 +1,1 @@
+Improve user checkpoints with structured AskUserQuestion across commands

--- a/commands/backdate-program.md
+++ b/commands/backdate-program.md
@@ -366,11 +366,58 @@ subagent_type: "general-purpose", team_name: "{st}-{prog}-backdate", name: "cons
 
 ### Regulatory Checkpoint 1
 
-Read ONLY `/tmp/{st}-{prog}-impl-summary.md`. Present to user:
-- Number of files affected, date entries to add
-- Any Tier B/C items (require user confirmation before proceeding)
-- Source gaps or unresolved conflicts
-- **Stop here if `--research-only`**
+Read ONLY `/tmp/{st}-{prog}-impl-summary.md`. Present a brief overview:
+
+```
+## {STATE_FULL} {PROGRAM} — Research Complete
+
+**Parameters**: {N} files, {M} date entries to add
+**Earliest date**: {YYYY-MM-DD} → backdating to {TARGET_YEAR}
+**Source gaps**: {count, if any}
+```
+
+Then walk through decisions one at a time using `AskUserQuestion`:
+
+**Decision 1: Proceed with implementation?**
+
+```
+AskUserQuestion:
+  Question: "Proceed with backdating {N} parameter files?"
+  Options:
+    - "Yes, proceed" (default/recommended)
+    - "Show me more details first"
+    - "Stop here (research only)"
+```
+
+**Decision 2: Tier B/C items** (only if impl-summary lists any)
+
+For each Tier B/C item, ask separately:
+
+```
+AskUserQuestion:
+  Question: "{Description of Tier B/C item}"
+  Description: "{Brief context — e.g., 'New parameter needed for provision X, not in current implementation'}"
+  Options:
+    - "Include — implement this change" (recommended if Tier B)
+    - "Skip — defer to follow-up PR"
+    - "Need more info"
+```
+
+**Decision 3: Source gaps** (only if impl-summary lists any)
+
+```
+AskUserQuestion:
+  Question: "How to handle {N} source gap(s)?"
+  Description: |
+    {List each gap, e.g.:
+    - No PDF found for 2003-2007 period
+    - Two sources disagree on 2010 value}
+  Options:
+    - "Proceed — use best available data" (recommended)
+    - "Pause — let me find the missing sources"
+```
+
+**Stop here if `--research-only`.**
 
 ---
 
@@ -437,10 +484,58 @@ Write SHORT summary (max 15 lines) to /tmp/{st}-{prog}-phase2-summary.md."
 
 ### Regulatory Checkpoint 2
 
-Read ONLY `/tmp/{st}-{prog}-phase2-summary.md`. Present to user:
-- Broken URLs, generic refs, missing subsections count
-- Unused parameters, zero-sentinels, missing provisions count
-- **Formula fixes require user confirmation** before implementation
+Read ONLY `/tmp/{st}-{prog}-phase2-summary.md`. Present a brief overview:
+
+```
+## Audit Results
+
+**References**: {N} broken URLs, {M} generic refs, {P} missing subsections
+**Formulas**: {X} unused params, {Y} zero-sentinels, {Z} missing provisions
+```
+
+Then walk through decisions using `AskUserQuestion`:
+
+**Decision 1: Reference fixes**
+
+```
+AskUserQuestion:
+  Question: "Apply {N} reference fixes? (broken URLs, missing page numbers, generic citations)"
+  Options:
+    - "Yes, fix all" (default/recommended)
+    - "Show me the list first"
+    - "Skip reference fixes"
+```
+
+**Decision 2: Formula fixes** (only if audit found formula issues)
+
+Ask for each formula fix category separately:
+
+```
+AskUserQuestion:
+  Question: "Fix {X} unused parameters? (parameters exist but no formula reads them)"
+  Options:
+    - "Yes, wire them into formulas" (recommended)
+    - "Skip — defer to follow-up"
+    - "Show me which ones"
+```
+
+```
+AskUserQuestion:
+  Question: "Fix {Y} zero-sentinel anti-patterns? (value=0 used instead of explicit in_effect boolean)"
+  Options:
+    - "Yes, refactor to in_effect pattern" (recommended)
+    - "Skip — cosmetic, defer"
+```
+
+```
+AskUserQuestion:
+  Question: "Implement {Z} missing provisions? (regulations found but not yet coded)"
+  Description: "{Brief list of missing provisions}"
+  Options:
+    - "Yes, implement all"
+    - "Let me pick which ones"
+    - "Skip — defer to follow-up PR"
+```
 
 ---
 

--- a/commands/encode-policy-v2.md
+++ b/commands/encode-policy-v2.md
@@ -171,37 +171,93 @@ After consolidator completes, read ONLY:
 
 ## Phase 2: Scope Review (USER CHECKPOINT)
 
-Present to user:
+This phase walks the user through scope decisions one at a time using `AskUserQuestion` with structured options. Do NOT dump all requirements at once.
+
+### Step 2A: Show Summary
+
+Display a brief overview (from scope-summary.md):
 
 ```
 ## {STATE} {PROGRAM} — Scope Review
 
 **Complexity**: {Simple/Complex} ({N} requirements)
 **Reference impl**: {path}
-
-### Requirements Found ({N} total):
-REQ-001: [ELIGIBILITY] Income <= 261% FPL (entry) — OAR 461-155-0180
-REQ-002: [ELIGIBILITY] Income <= 300% FPL (transitional) — OAR 461-155-0180
-REQ-003: [RESOURCE] Assets <= $1M — OAR 461-160-0015
-REQ-004: [DEMOGRAPHIC] Child under 13 (under 19 if disabled) — OAR 461-120-0510
-REQ-005: [IMMIGRATION] Child must be US citizen or qualified immigrant — 8 USC 1612
-REQ-006: [BENEFIT] Co-payment 0%/2%/5%/7% by FPL tier — OAR 461-155-0150
-REQ-007: [BENEFIT] Co-payment capped at 7% of income (federal) — 45 CFR 98.45
-REQ-008: [EXEMPTION] RI Works families get $0 co-payment — DHS Policy Manual
-REQ-009: [NOT-MODELED] 20 hrs/week work activity requirement — OAR 461-135-0400
-...
-
-Implement all? Or exclude any? (e.g., "Skip REQ-009, REQ-010")
 ```
 
-Wait for user response via AskUserQuestion.
+Then list requirements grouped by tag. Example:
 
-User can say:
-- "All" — implement everything (except NOT-MODELED)
-- "Skip REQ-009, REQ-010" — orchestrator records exclusions
-- Any other guidance
+```
+### Requirements Found ({N} total):
 
-Write the decision to `/tmp/{PREFIX}-scope-decision.md`:
+**Eligibility** ({X})
+  REQ-001: Income <= 261% FPL (entry) — OAR 461-155-0180
+  REQ-002: Income <= 300% FPL (transitional) — OAR 461-155-0180
+
+**Benefit Calculation** ({X})
+  REQ-006: Co-payment 0%/2%/5%/7% by FPL tier — OAR 461-155-0150
+  REQ-007: Co-payment capped at 7% of income — 45 CFR 98.45
+
+**Not Modeled** ({X})
+  REQ-009: 20 hrs/week work activity requirement — OAR 461-135-0400
+```
+
+### Step 2B: Key Decisions (One at a Time)
+
+For each key decision point identified in the scope summary, ask the user ONE question at a time using `AskUserQuestion`.
+
+**Decision 1: Overall scope**
+
+```
+AskUserQuestion:
+  Question: "Implement all {N} simulatable requirements? ({M} NOT-MODELED items will be excluded automatically)"
+  Options:
+    - "Yes, implement all" (default/recommended)
+    - "Let me pick which to skip"
+```
+
+If user picks "Let me pick which to skip", present each questionable requirement group:
+
+```
+AskUserQuestion:
+  Question: "Include {TAG} requirements?"
+  Description: |
+    REQ-XXX: {description}
+    REQ-YYY: {description}
+  Options:
+    - "Yes, include all" (default)
+    - "Skip these"
+    - "Let me pick individually"
+```
+
+**Decision 2+: Program-specific complexity decisions**
+
+If the scope summary identifies key decision points (e.g., provider rates, simplified vs full approach), ask each as a separate question:
+
+```
+AskUserQuestion:
+  Question: "{Decision description}"
+  Description: "{Brief context — e.g., 'Provider rates have ~240 rate cells. Implementing now adds complexity.'}"
+  Options:
+    - "{Option A}" (recommended if applicable)
+    - "{Option B}"
+    - "{Option C if needed}"
+```
+
+Examples of program-specific decisions:
+- "Provider rates have ~240 rate cells — implement now or defer?"
+  - "Defer to follow-up PR" (recommended)
+  - "Implement now"
+- "TANF approach — simplified or full?"
+  - "Simplified (eligibility + benefit amount)" (recommended)
+  - "Full (all components)"
+- "13 income types have no PE equivalent — how to handle?"
+  - "Map to closest existing variables" (recommended)
+  - "Create new variables for each"
+  - "Skip unmappable income types"
+
+### Step 2C: Write Scope Decision
+
+After all questions are answered, write the decision to `/tmp/{PREFIX}-scope-decision.md`:
 
 ```markdown
 ## Scope Decision for {STATE} {PROGRAM}
@@ -213,7 +269,11 @@ REQ-002: [ELIGIBILITY] Income <= 300% FPL (transitional)
 
 ### Excluded
 REQ-009: [NOT-MODELED] 20 hrs/week work activity — Reason: not simulatable
-REQ-010: [BENEFIT] Provider payment rates — Reason: user excluded
+REQ-010: [BENEFIT] Provider payment rates — Reason: user deferred
+
+### Key Decisions
+- Provider rates: deferred to follow-up PR
+- Income variable gaps: map to closest existing variables
 
 ### User Notes
 {any additional guidance from user}

--- a/commands/fix-pr.md
+++ b/commands/fix-pr.md
@@ -1,64 +1,79 @@
 ---
-description: Apply fixes to a PR based on review-pr findings or review comments
+description: Apply fixes to a PR based on /review-pr, /review-program findings, or PR review comments
 ---
 
 # Fixing PR: $ARGUMENTS
 
-Apply fixes to PR issues identified by `/review-pr` or GitHub review comments.
+Apply fixes to PR issues identified by `/review-pr`, `/review-program`, or GitHub review comments.
 
-## Options
+## Arguments
 
-- `--local` - Apply fixes locally only, skip GitHub posting and pushing
+`$ARGUMENTS` should contain:
+- **PR number or title** (optional) — e.g., `6390` or `"Arkansas TANF"`. If omitted, prompts.
+- **Options**:
+  - `--local` — apply fixes locally only, skip GitHub posting and pushing
 
-## Step 1: Determine Posting Mode
-
-**If `--local` flag is provided**: Skip prompt, proceed in local-only mode.
-
-**If no flag provided**: Use `AskUserQuestion` to prompt BEFORE starting fixes:
-
+**Examples:**
+```bash
+/fix-pr              # Fix PR for current branch (prompts for everything)
+/fix-pr 6390         # Fix PR #6390
+/fix-pr "Arkansas"   # Search for PR by title
+/fix-pr --local      # Fix current branch's PR, keep changes local
+/fix-pr 6390 --local # Fix PR #6390, keep changes local
 ```
-Question: "Would you like to push changes and post summary to GitHub when complete?"
-Options:
-  - "Yes, push and post to GitHub" (default)
-  - "No, keep changes local only"
-```
-
-Store the user's choice and proceed with the fixes.
 
 ---
 
-## Step 2: Determine Which PR to Fix
+## YOUR ROLE: COORDINATOR ONLY
+
+**CRITICAL — Context Window Protection:**
+- You are a coordinator. You do NOT read diffs, code files, or full review reports.
+- ALL information-gathering work is delegated to agents.
+- You only read files marked "Short" in the handoff table (max 50 lines each).
+- ALL data flows through files on disk. Agent prompts reference file paths, never paste content.
+
+**You MUST NOT:**
+- Read the PR diff (`/tmp/fix-pr-diff.txt`)
+- Read parameter YAML files or variable .py files
+- Read full review reports directly
+- Use Edit/Write directly — agents handle all code changes
+
+**You DO:**
+- Parse arguments
+- Run `gh` commands for small structured JSON
+- Save diff to disk for agents
+- Read SHORT summary files only
+- Present checkpoints to user via `AskUserQuestion`
+- Spawn agents for all fixes
+
+---
+
+## Phase 0: Parse Arguments & Setup
+
+### Step 0A: Parse Arguments & Clean Up
+
+**Clean up leftover files from previous runs:**
+```bash
+rm -f /tmp/fix-pr-*.md /tmp/fix-pr-diff.txt
+```
+
+```
+Parse $ARGUMENTS:
+- PR_ARG: first non-flag argument (number or search text)
+- LOCAL_ONLY: true if --local flag present
+```
+
+**Derive PREFIX** (for reading local /review-program files):
+```bash
+PREFIX=$(git branch --show-current | tr '/' '-')
+PREFIX=${PREFIX:-fix-pr}
+```
+
+### Step 0B: Determine Which PR to Fix
 
 ```bash
-# Parse arguments for --local flag
-LOCAL_ONLY=false
-PR_ARG=""
-for arg in $ARGUMENTS; do
-    if [ "$arg" = "--local" ]; then
-        LOCAL_ONLY=true
-    else
-        PR_ARG="$arg"
-    fi
-done
-```
-
-**If no PR argument provided**: Use `AskUserQuestion` to ask for the PR:
-
-```
-Question: "Which PR would you like to fix?"
-Header: "PR"
-Options:
-  - "Enter PR number" (e.g., 6390)
-  - "Enter PR name/title" (e.g., "Arkansas TANF")
-```
-
-Then use the provided value to find the PR.
-
-```bash
-# If argument is a number, use it directly
 if [[ "$PR_ARG" =~ ^[0-9]+$ ]]; then
     PR_NUMBER=$PR_ARG
-# Otherwise, search for PR by description/title
 else
     PR_NUMBER=$(gh pr list --search "$PR_ARG" --json number,title --jq '.[0].number')
     if [ -z "$PR_NUMBER" ]; then
@@ -66,300 +81,564 @@ else
         exit 1
     fi
 fi
+```
 
-echo "Fixing PR #$PR_NUMBER"
-if [ "$LOCAL_ONLY" = true ]; then
-    echo "Mode: Local only (will not post to GitHub or push)"
-fi
+**If no PR argument provided**: Use `AskUserQuestion`:
+
+```
+AskUserQuestion:
+  Question: "Which PR would you like to fix?"
+  Options:
+    - "Enter PR number (e.g., 6390)"
+    - "Enter PR name/title (e.g., 'Arkansas TANF')"
+```
+
+Then resolve the PR number and checkout:
+
+```bash
 gh pr checkout $PR_NUMBER
 ```
 
----
+### Step 0C: Determine Posting Mode
 
-## Coordinator Role
+**If `--local` flag**: Skip prompt, proceed in local-only mode.
 
-**You are a coordinator, NOT an implementer.**
+**If no flag**: Use `AskUserQuestion`:
 
-- ✅ Invoke agents with specific instructions
-- ✅ Wait for agents to complete
-- ✅ Verify fixes worked
-- ❌ Never use Edit/Write directly
-- ❌ Never write code yourself
+```
+AskUserQuestion:
+  Question: "Push changes and post summary to GitHub when complete?"
+  Options:
+    - "Yes, push and post to GitHub" (default)
+    - "No, keep changes local only"
+```
 
 ---
 
 ## Phase 1: Gather Context
 
-Collect information about issues to fix:
+Main Claude runs small structured commands only:
 
 ```bash
-gh pr view $PR_NUMBER --comments
+gh pr view $PR_NUMBER --json title,body,author,baseRefName,headRefName
 gh pr checks $PR_NUMBER
-gh pr diff $PR_NUMBER
+gh pr diff $PR_NUMBER > /tmp/fix-pr-diff.txt
 ```
 
-**Parse findings into categories:**
+**Main Claude does NOT read the diff file.** It saves it to disk for the context agent.
 
-| Priority | Examples |
-|----------|----------|
-| 🔴 Critical | Hard-coded values, missing references, regulatory mismatch, CI failures |
-| 🟡 Should | Pattern violations, missing tests, naming issues |
-| 🟢 Suggestions | Documentation, performance |
+Check for local `/review-program` files from a previous run:
 
-**Create fix plan** listing each issue and which agent will fix it.
+```bash
+ls /tmp/${PREFIX}-review-full-report.md 2>/dev/null && echo "LOCAL_REVIEW=true" || echo "LOCAL_REVIEW=false"
+```
+
+### Step 1A: Delegate context gathering
+
+```
+subagent_type: "general-purpose"
+name: "context-gatherer"
+
+"Analyze PR #{PR_NUMBER} to identify issues that need fixing.
+
+READ:
+- /tmp/fix-pr-diff.txt (the PR diff)
+
+SOURCES — check both, use whichever has findings (or both):
+
+1. LOCAL REVIEW FILES (from a /review-program run in this session):
+   - /tmp/{PREFIX}-review-full-report.md (if it exists)
+   - /tmp/{PREFIX}-review-summary.md (if it exists)
+
+2. PR COMMENTS AND REVIEWS (from GitHub):
+   Run these commands to get review data:
+   - gh pr view {PR_NUMBER} --json reviews --jq '.reviews[] | {author: .author.login, state: .state, submittedAt: .submittedAt, body: .body}'
+   - gh pr view {PR_NUMBER} --json comments --jq '.comments[] | {author: .author.login, createdAt: .createdAt, body: .body}'
+   - gh pr view {PR_NUMBER} --json commits --jq '.commits[-1].committedDate'
+
+COMMENT FRESHNESS — determine which PR comments are still valid:
+
+1. Get the last commit timestamp from the commits query above.
+2. For each comment/review:
+   a. If posted AFTER last commit → CURRENT (all valid)
+   b. If posted BEFORE last commit → check staleness:
+      - Thread resolved on GitHub? → RESOLVED (skip)
+      - The flagged file/line was modified in a commit after the comment?
+        Check with: git log --oneline --after='{comment_date}' -- '{file_path}'
+        If modified → POSSIBLY-FIXED
+      - Otherwise → STALE-BUT-OPEN (still valid, flag for user)
+3. Ignore reviews with state DISMISSED.
+4. Include ALL comments from all authors — do not deduplicate by author.
+   (A reviewer may leave multiple separate comments on different issues.)
+
+TASK:
+1. Merge findings from local review files AND valid PR comments (deduplicate
+   if the same issue appears in both — prefer the more detailed version)
+2. For each issue, classify:
+   - CLEAR: obviously fixable (missing reference, formatting, hard-coded value)
+   - AMBIGUOUS: might be by design or needs verification (regulatory mismatch,
+     value discrepancy, unusual pattern choice)
+   - RESEARCH-NEEDED: requires checking the review report evidence before deciding
+
+3. Write /tmp/fix-pr-issues.md (max 50 lines):
+
+   ## Issues for PR #{PR_NUMBER}
+
+   ### Source Summary
+   - Local /review-program report: {found / not found}
+   - PR comments: {N} from {authors}
+     - {X} current (after last commit on {date})
+     - {Y} stale-but-open (before last commit, file not modified since)
+     - {Z} possibly-fixed (before last commit, file modified since)
+     - {W} resolved (skipped)
+
+   ### Critical ({N})
+   - [CLEAR] Missing reference in {file} — no citation (source: review-program)
+   - [AMBIGUOUS] Regulatory mismatch in {file} — code uses 200% FPL, review says 185% (source: @author, Mar 3)
+   - [RESEARCH-NEEDED] Value mismatch: repo=$500, PDF=$485 in {file} (source: review-program)
+   - [CLEAR] [POSSIBLY-FIXED] Hard-coded value in {file} (source: @author, Feb 28 — file modified Mar 1)
+
+   ### Should Address ({M})
+   - [CLEAR] Pattern violation in {file} — use add() not manual sum (source: review-program)
+   - [CLEAR] Missing boundary test for {variable} (source: @author, Mar 3)
+
+   ### Suggestions ({P})
+   - [CLEAR] Add docstring to {variable} (source: review-program)
+
+   ### Summary
+   - Total: {N+M+P}
+   - Clear: {count}, Ambiguous: {count}, Research needed: {count}
+   - Possibly already fixed: {count}"
+```
+
+Read ONLY `/tmp/fix-pr-issues.md` (max 50 lines).
 
 ---
 
-## Phase 2: Fix Critical Issues
+## Phase 2: Fix Plan Checkpoint (USER CHECKPOINT)
 
-**Fix in dependency order**: Parameters → Variables → Tests
+Present a brief overview from the issues file:
 
-### Step 2A: Fix Reference Issues
-
-If references are missing or incorrect:
-
-**Invoke parameter-architect**:
 ```
-Fix reference issues in these parameter files:
-- [file1]: Missing reference
-- [file2]: Reference doesn't corroborate value (says X, should be Y)
-- [file3]: Missing PDF page number
+## PR #{PR_NUMBER} — Issues Found
 
-Requirements:
+**Critical**: {N} issues
+**Should Address**: {M} issues
+**Suggestions**: {P} issues
+**Possibly already fixed**: {K} issues
+```
+
+Then walk through decisions using `AskUserQuestion`:
+
+### Step 2A: Fix scope
+
+```
+AskUserQuestion:
+  Question: "Which issue categories should I fix?"
+  Options:
+    - "Critical only" (recommended if Critical > 0)
+    - "Critical + Should Address" (recommended if Critical == 0)
+    - "All including Suggestions"
+    - "Let me review each issue"
+```
+
+### Step 2B: Possibly-fixed issues (only if any exist)
+
+For each `POSSIBLY-FIXED` issue within the chosen scope:
+
+```
+AskUserQuestion:
+  Question: "[POSSIBLY-FIXED] {issue description}"
+  Description: "Flagged by @{author} on {date}, but {file} was modified on {later_date}."
+  Options:
+    - "Already fixed — skip" (recommended)
+    - "Still an issue — fix it"
+    - "Not sure — check it"
+```
+
+### Step 2C: Per-issue review (only if user chose "Let me review each issue")
+
+For each issue in scope, present it with context. Options vary by classification:
+
+**CLEAR issues** (e.g., missing reference, formatting violation):
+
+```
+AskUserQuestion:
+  Question: "[Critical] Missing reference in {file}"
+  Description: "Parameter has no citation — needs a regulatory source link"
+  Options:
+    - "Fix" (default)
+    - "Skip"
+```
+
+**AMBIGUOUS issues** (e.g., regulatory mismatch, unusual pattern):
+
+```
+AskUserQuestion:
+  Question: "[Critical] Regulatory mismatch in {file}"
+  Description: "Code uses 200% FPL threshold but regulation says 185% FPL. This could be intentional if the state has a transitional rate or waiver."
+  Options:
+    - "Fix — code should match regulation"
+    - "Not an issue — this is by design"
+    - "Needs research — check review report for evidence"
+```
+
+**RESEARCH-NEEDED issues** (e.g., value discrepancy, ambiguous regulation):
+
+```
+AskUserQuestion:
+  Question: "[Critical] Value mismatch: repo=$500, PDF=$485 in {file}"
+  Description: "Could be an uprating difference, a different edition of the source, or a genuine error."
+  Options:
+    - "Research first — check review report for evidence"
+    - "Fix — use the PDF value"
+    - "Not an issue — repo value is correct"
+```
+
+### Step 2D: Evidence extraction (for issues needing research)
+
+For issues where the user chose "Research first" or "Needs research": extract evidence from the review report. Spawn one per issue — they run **in parallel**:
+
+```
+subagent_type: "general-purpose"
+name: "evidence-extractor-{N}"
+run_in_background: true
+
+"Extract evidence for a specific issue from the review report.
+
+ISSUE: {description} in {file}
+QUESTION: {what needs to be determined}
+
+READ (check both, use whichever exists):
+- /tmp/{PREFIX}-review-full-report.md (local review-program output)
+- PR comments via: gh pr view {PR_NUMBER} --comments
+
+Find the section(s) related to this issue and extract:
+- The regulation citation and what it says
+- The code-path verification result (if any)
+- The visual verification result (if any)
+- The reviewer's assessment
+
+Write to /tmp/fix-pr-research-{N}.md (max 15 lines):
+- Source: {regulation citation}
+- Evidence from review: {what the report found}
+- Verdict: CONFIRMED BUG / BY DESIGN / AMBIGUOUS
+- Recommended action: fix (describe how) / leave as-is / needs human judgment"
+```
+
+After all extractors complete, read each `/tmp/fix-pr-research-{N}.md` and re-ask:
+
+```
+AskUserQuestion:
+  Question: "Research result for: {issue description}"
+  Description: "{Brief summary of findings — verdict and evidence}"
+  Options:
+    - "{Recommended action from research}" (recommended)
+    - "{Alternative action}"
+    - "Skip — I'll handle this manually"
+```
+
+### Step 2E: Write fix plan to disk
+
+After all decisions are made, write `/tmp/fix-pr-plan.md`:
+
+```markdown
+## Fix Plan for PR #{PR_NUMBER}
+
+### Confirmed Fixes
+- [2A] {file}: Missing reference — parameter-architect
+- [2B] {file}: Regulatory mismatch — rules-engineer
+- [2B] {file}: Hard-coded value — rules-engineer (depends on 2A)
+- [2C] {variable}: Missing boundary test — edge-case-generator
+
+### Skipped
+- {file}: Regulatory mismatch — user marked "by design"
+- {file}: Hard-coded value — already fixed (POSSIBLY-FIXED confirmed)
+
+### Fix Order
+1. Parameter fixes: {count} issues → parameter-architect
+2. Variable fixes: {count} issues → rules-engineer (after parameters)
+3. Test fixes: {count} issues → edge-case-generator (after variables)
+4. CI fixes: run after all above → ci-fixer
+```
+
+---
+
+## Phase 3: Apply Fixes
+
+**Only fix issues listed in `/tmp/fix-pr-plan.md`.** Skip anything excluded.
+
+**Fix in dependency order**: Parameters → Variables → Tests → CI.
+
+### Step 3A: Parameter Fixes
+
+Skip if no parameter issues in the fix plan.
+
+```
+subagent_type: "complete:country-models:parameter-architect"
+name: "fix-parameters"
+
+"Fix parameter issues for PR #{PR_NUMBER}.
+Read the fix plan at /tmp/fix-pr-plan.md — fix ONLY the issues assigned to you.
+
+Load skills: /policyengine-parameter-patterns.
+
+For reference issues:
 - Add detailed section numbers (e.g., 42 USC 8624(b)(2)(B))
-- Add #page=XX for PDF links
-- Ensure clicking link shows the value
+- Add #page=XX for PDF links (file page, NOT printed page)
+
+For new parameters:
+- Create in proper hierarchy (federal vs state)
+- Include references for every new parameter value
+
+DO NOT commit — Phase 4 handles all commits."
 ```
 
-### Step 2B: Fix Hard-Coded Values
+### Step 3B: Variable Fixes
 
-If hard-coded values found in variables:
+Skip if no variable issues in the fix plan. **Depends on Step 3A** — wait for parameter fixes to complete if new parameters were created.
 
-**Step 1 - Invoke parameter-architect**:
 ```
-Create parameters for these hard-coded values:
-- [file1:line]: value 65 (age threshold)
-- [file2:line]: value 0.3 (rate)
-- [file3:line]: value 2000 (income limit)
+subagent_type: "complete:country-models:rules-engineer"
+name: "fix-variables"
 
-Create in proper hierarchy (federal vs state).
-Include references for each value.
-```
+"Fix variable issues for PR #{PR_NUMBER}.
+Read the fix plan at /tmp/fix-pr-plan.md — fix ONLY the issues assigned to you.
 
-**Step 2 - Invoke rules-engineer**:
-```
-Refactor these variables to use the new parameters:
-- [file1]: Replace hard-coded 65 with parameter
-- [file2]: Replace hard-coded 0.3 with parameter
-- [file3]: Replace hard-coded 2000 with parameter
+Load skills: /policyengine-variable-patterns, /policyengine-code-style.
 
-Use proper parameter access pattern.
+If Step 3A created new parameters, read them from disk before refactoring.
+Use proper parameter access patterns.
+
+DO NOT commit — Phase 4 handles all commits."
 ```
 
-### Step 2C: Fix Regulatory Mismatches
+### Step 3C: Test Fixes
 
-If implementation doesn't match regulations:
+Skip if no test issues in the fix plan. **Depends on Step 3B** — tests should reflect the fixed variable behavior.
 
-**Invoke rules-engineer**:
 ```
-Fix regulatory mismatch in [file]:
-- Current: [what code does]
-- Should be: [what regulation says]
-- Source: [regulation citation]
+subagent_type: "complete:country-models:edge-case-generator"
+name: "fix-tests"
 
-Update the formula to match the regulation.
+"Add missing tests for PR #{PR_NUMBER}.
+Read the fix plan at /tmp/fix-pr-plan.md — fix ONLY the issues assigned to you.
+
+Load skills: /policyengine-testing-patterns.
+
+Always append new cases at the bottom of existing test files.
+Never insert in the middle — this renumbers existing cases and creates noisy diffs.
+
+DO NOT commit — Phase 4 handles all commits."
 ```
 
-### Step 2D: Fix CI Failures
+### Step 3D: CI Fixes
 
-If CI is failing:
+Run **after Steps 3A-3C** to catch failures from the fixes themselves.
 
-**Invoke ci-fixer**:
 ```
-Fix CI failures for PR #$PR_NUMBER:
-- Test failures: [list failing tests]
-- Lint failures: [list lint issues]
+subagent_type: "complete:country-models:ci-fixer"
+name: "fix-ci"
 
-Run tests locally, fix issues, iterate until passing.
+"Run tests for PR #{PR_NUMBER} and fix any failures.
+Load skills: /policyengine-testing-patterns, /policyengine-variable-patterns.
+
+Run: policyengine-core test {test path} -c policyengine_us -v
+Fix failures. Iterate until pass. Run make format.
+
+Write SHORT result to /tmp/fix-pr-ci-result.md (max 10 lines):
+- Tests: PASS / FAIL (N failures)
+- Fixes applied: {list}
+- Format: done"
 ```
+
+Read ONLY `/tmp/fix-pr-ci-result.md` (max 10 lines).
+
+**If ci-fixer fails after 3 iterations**: Stop and report to user.
 
 ---
 
-## Phase 3: Fix Should-Address Issues
+## Phase 4: Verify & Push
 
-### Step 3A: Fix Pattern Violations
+### Step 4A: Quick Audit
 
-If code patterns are wrong:
+Spawn a verification agent to check the fixes didn't introduce new problems:
 
-**Invoke implementation-validator**:
 ```
-Fix pattern violations in these files:
-- [file1]: Use `add()` instead of manual sum
-- [file2]: Use `adds` attribute instead of formula
-- [file3]: Use `add() > 0` instead of `spm_unit.any()`
-- [file4]: Reference should use tuple () not list []
+subagent_type: "complete:country-models:implementation-validator"
+name: "fix-verifier"
 
-Apply fixes following policyengine-code-style-skill patterns.
-```
+"Verify fixes for PR #{PR_NUMBER} were applied correctly.
+Read the fix plan at /tmp/fix-pr-plan.md.
+Load skills: /policyengine-variable-patterns, /policyengine-parameter-patterns,
+  /policyengine-code-style.
 
-### Step 3B: Add Missing Tests
+Check:
+- Each issue in the fix plan was actually addressed
+- No new hard-coded values introduced
+- All new parameters have references
+- Patterns are correct (adds, add(), entity levels)
 
-If tests are missing:
-
-**Invoke edge-case-generator**:
-```
-Add missing tests for:
-- [variable1]: Missing boundary test at threshold
-- [variable2]: Missing zero income case
-- [variable3]: Missing maximum household size case
-
-Always append new cases at the bottom of existing test files. Never insert in the middle — this renumbers existing cases and creates noisy diffs.
+Write SHORT report to /tmp/fix-pr-verification.md (max 15 lines):
+- Issues fixed: {count} / {total in plan}
+- New issues introduced: {count, if any}
+- Verdict: CLEAN / HAS-ISSUES"
 ```
 
-### Step 3C: Fix Naming Issues
+Read ONLY `/tmp/fix-pr-verification.md` (max 15 lines).
 
-If naming conventions violated:
+**If HAS-ISSUES**: Spawn ci-fixer to address. If still failing after 1 round, report to user and proceed.
 
-**Invoke implementation-validator**:
-```
-Fix naming convention issues:
-- [file1]: Variable should be {state}_{program}_{concept}
-- [file2]: Parameter folder should be in states/{state}/
+### Step 4B: Cleanup & Push
 
-Rename files and update all references.
-```
-
----
-
-## Phase 4: Verify All Fixes
-
-After all fixes applied, verify nothing is broken:
-
-### Step 4A: Run Validators
-
-**Invoke implementation-validator** (read-only check):
-```
-Verify all fixes were applied correctly:
-- No remaining hard-coded values
-- All patterns correct
-- All naming conventions followed
-```
-
-**Invoke reference-validator** (read-only check):
-```
-Verify all references are correct:
-- All parameters have references
-- References corroborate values
-- PDF pages included
-```
-
-### Step 4B: Run Tests Locally
+**Cleanup** (always, regardless of local/push mode):
 
 ```bash
-# Run tests for the affected program
-policyengine-core test policyengine_us/tests/policy/baseline/gov/states/[STATE]/[AGENCY]/[PROGRAM] -c policyengine_us -v
+# Remove working_references.md — useful during development but should not be committed
+rm -f sources/working_references.md
 ```
 
-If tests fail, invoke **ci-fixer** to fix.
+**If user chose local-only mode**: Run `make format`, then skip to Phase 5.
 
----
-
-## Phase 5: Push Changes
-
-**If user chose local-only mode**: Show summary locally and skip pushing/posting.
-
-**If user chose to push to GitHub**: Continue with pushing and posting.
-
-### Step 5A: Format and Push (if user chose to push)
-
-**Invoke pr-pusher**:
-```
-Push fixes to PR #$PR_NUMBER:
-- Run make format
-- Commit with message describing fixes
-- Push to branch
-```
-
-### Step 5B: Post Summary Comment (if user chose to push)
+**If user chose to push to GitHub**:
 
 ```bash
-gh pr comment $PR_NUMBER --body "## Fixes Applied
+# Rebase on upstream before pushing to avoid merge conflicts
+git pull --rebase origin main || git pull --rebase origin master
+```
 
-### 🔴 Critical Issues Fixed
-- ✅ [Issue 1]: [How it was fixed]
-- ✅ [Issue 2]: [How it was fixed]
+```
+subagent_type: "complete:country-models:pr-pusher"
+name: "fix-pusher"
 
-### 🟡 Should-Address Issues Fixed
-- ✅ [Issue 1]: [How it was fixed]
-- ✅ [Issue 2]: [How it was fixed]
+"Push fixes for PR #{PR_NUMBER}:
+- Run make format (skip if ci-fixer already ran it — check /tmp/fix-pr-ci-result.md)
+- git add changed files
+- Ensure sources/working_references.md is NOT staged (it was deleted as cleanup)
+- git commit -m 'Fix issues from review: {brief summary of what was fixed}'
+- git push"
+```
+
+### Step 4C: Post Summary Comment
+
+**If user chose local-only mode**: Skip.
+
+**If user chose to push to GitHub**: Spawn an agent to write the comment based on actual fixes applied:
+
+```
+subagent_type: "general-purpose"
+name: "comment-writer"
+
+"Write a GitHub PR comment summarizing fixes applied to PR #{PR_NUMBER}.
+
+READ:
+- /tmp/fix-pr-plan.md (what was planned)
+- /tmp/fix-pr-ci-result.md (test results)
+- /tmp/fix-pr-verification.md (verification results)
+
+Write /tmp/fix-pr-comment.md:
+
+## Fixes Applied
+
+### Critical Issues Fixed
+- {issue}: {how it was fixed}
+
+### Should-Address Issues Fixed
+- {issue}: {how it was fixed}
+
+### Skipped (by user decision)
+- {issue}: {reason}
 
 ### Verification
-- ✅ All validators pass
-- ✅ All tests pass locally
-- ✅ Code formatted
+- Tests: {pass/fail}
+- Validator: {clean/issues}
+- Format: done
 
-Ready for re-review."
+Only include sections that have entries."
+```
+
+Then post:
+
+```bash
+gh pr comment $PR_NUMBER --body-file /tmp/fix-pr-comment.md
+```
+
+---
+
+## Phase 5: Summary
+
+Present to user:
+
+```
+## Fix Summary for PR #{PR_NUMBER}
+
+- Issues fixed: {X} / {total found}
+- Skipped: {Y} (by design: {A}, already fixed: {B}, user skipped: {C})
+- Tests: {pass/fail}
+- Pushed: {yes/no}
+- Comment posted: {yes/no}
 ```
 
 ---
 
 ## Issue Type → Agent Mapping
 
-| Issue Type | Agent |
-|------------|-------|
-| Missing reference | parameter-architect |
-| Bad reference format | parameter-architect |
-| Hard-coded value (create param) | parameter-architect |
-| Hard-coded value (use param) | rules-engineer |
-| Regulatory mismatch | rules-engineer |
-| Pattern violation | implementation-validator |
-| Naming issue | implementation-validator |
-| Missing test | edge-case-generator |
-| CI failure | ci-fixer |
-| Format issue | pr-pusher |
+| Issue Type | Step | Agent (`complete:country-models:` prefix) |
+|------------|------|-------|
+| Missing reference | 3A | `parameter-architect` |
+| Bad reference format | 3A | `parameter-architect` |
+| Hard-coded value (create param) | 3A | `parameter-architect` |
+| Hard-coded value (use param) | 3B | `rules-engineer` |
+| Regulatory mismatch | 3B | `rules-engineer` |
+| Pattern violation (adds, add()) | 3B | `rules-engineer` |
+| Naming issue | 3B | `rules-engineer` |
+| Missing test | 3C | `edge-case-generator` |
+| CI failure | 3D | `ci-fixer` |
+| Format issue | 4B | `pr-pusher` |
 
 ---
 
-## Usage Examples
+## Handoff Table
 
-```bash
-/fix-pr              # Fix PR for current branch (prompts before pushing)
-/fix-pr 6390         # Fix PR #6390 (prompts before pushing)
-/fix-pr "Arkansas"   # Search for PR by title (prompts before pushing)
-/fix-pr --local      # Fix current branch's PR, keep changes local
-/fix-pr 6390 --local # Fix PR #6390, keep changes local
-```
+| File | Written By | Read By | Size |
+|------|-----------|---------|------|
+| `/tmp/fix-pr-diff.txt` | Main Claude (gh pr diff) | context-gatherer | Full |
+| `/tmp/fix-pr-issues.md` | context-gatherer | Main Claude | Short (50 lines) |
+| `/tmp/fix-pr-plan.md` | Main Claude | all fix agents, verifier | Short |
+| `/tmp/fix-pr-research-{N}.md` | evidence-extractor-{N} | Main Claude | Short (15 lines) |
+| `/tmp/fix-pr-ci-result.md` | ci-fixer | Main Claude, comment-writer | Short (10 lines) |
+| `/tmp/fix-pr-verification.md` | fix-verifier | Main Claude, comment-writer | Short (15 lines) |
+| `/tmp/fix-pr-comment.md` | comment-writer | gh pr comment --body-file | Full |
+| `/tmp/{PREFIX}-review-full-report.md` | /review-program (prior run) | context-gatherer, evidence-extractor | Full |
+
+**Main Claude reads ONLY "Short" files. Never read "Full" files.**
 
 ---
 
-## Fix Order (Important!)
+## Error Handling
 
-Always fix in this order to avoid cascading issues:
-
-```
-1. Parameters (foundation)
-   └─ References, values, structure
-
-2. Variables (depend on parameters)
-   └─ Hard-coded values, patterns, logic
-
-3. Tests (depend on variables)
-   └─ Missing tests, edge cases
-
-4. Format & Push (last)
-   └─ make format, commit, push
-```
+| Category | Example | Action |
+|----------|---------|--------|
+| **Recoverable** | Test failure, lint error | ci-fixer handles automatically |
+| **Agent failure** | fix-variables crashes | Report which agent failed, ask user |
+| **CI stuck** | ci-fixer fails 3 iterations | Stop, report remaining failures to user |
+| **No issues found** | Empty issues file | Report "nothing to fix" and exit |
+| **No review data** | No local report AND no PR comments | Report "no review findings found — run /review-program first?" |
 
 ---
 
 ## Pre-Flight Checklist
 
 Before starting:
-- [ ] I will ask user about posting mode FIRST (unless --local flag used)
-- [ ] I will invoke agents for ALL fixes
-- [ ] I will NOT use Edit/Write directly
-- [ ] I will fix in dependency order (params → vars → tests)
-- [ ] I will verify fixes with validators
-- [ ] I will run tests before pushing
+- [ ] I will determine which PR FIRST, then ask posting mode
+- [ ] I will clean up /tmp/fix-pr-* files before starting
+- [ ] I will delegate ALL context gathering to agents
+- [ ] I will read ONLY short summary files
+- [ ] I will present issues to user via AskUserQuestion before fixing
+- [ ] I will write the fix plan to disk before spawning fix agents
+- [ ] I will invoke agents for ALL fixes — never use Edit/Write directly
+- [ ] I will fix in dependency order (params → vars → tests → CI)
+- [ ] I will verify fixes with implementation-validator after applying
+- [ ] I will generate the PR comment from actual results, not a template
 
-Start by asking the user about posting mode, then proceed through the phases.
+Start by parsing arguments (Phase 0), then proceed through all phases.


### PR DESCRIPTION
## Summary

Replaces vague "dump everything and ask open-ended question" checkpoints with structured `AskUserQuestion` calls — one decision at a time, with recommended options.

## Changes

### encode-policy-v2
- **Phase 2 (Scope Review)**: Requirements now displayed grouped by tag. Overall scope asked first, then each program-specific complexity decision separately (provider rates, TANF approach, income variable gaps) with recommended defaults.

### backdate-program
- **Regulatory Checkpoint 1** (after research): Structured questions for proceed/Tier B-C items/source gaps
- **Regulatory Checkpoint 2** (after audit): Structured questions for reference fixes and each formula fix category separately

### fix-pr (full rewrite)
- **Phase 0**: Proper setup — file cleanup, PREFIX derivation, PR selection before posting mode
- **Phase 1**: Delegated context gathering with comment freshness detection (CURRENT/STALE-BUT-OPEN/POSSIBLY-FIXED/RESOLVED)
- **Phase 2**: Per-issue checkpoint with clear/ambiguous/research-needed classification, evidence extraction from review reports
- **Phase 3**: Proper agent blocks with `subagent_type`, dependency-ordered execution, fix plan on disk
- **Phase 4**: Verification agent, working_references.md cleanup, git pull --rebase before push, comment generated from actual results
- **Phase 5**: Summary
- Added: handoff table, error handling, context protection rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)