### PR TITLE
Add frontend dev guardrails

### DIFF
--- a/changelog.d/frontend-dev-guardrails.added.md
+++ b/changelog.d/frontend-dev-guardrails.added.md
@@ -1,0 +1,1 @@
+Add frontend verification guardrails: require bun run build instead of curl for SPA verification, limit dependency troubleshooting to 2 attempts before asking user, prohibit destructive actions like rm -rf node_modules without approval

--- a/lessons/agent-lessons.md
+++ b/lessons/agent-lessons.md
@@ -31,3 +31,17 @@ Loaded by implementation agents on future runs.
 
 ## REFERENCE
 - PDF text extraction can misidentify state or program names from headers, footers, or watermarks; always verify the actual data content of a PDF rather than flagging it based on extracted metadata strings alone.
+
+# Frontend Development Lessons (2026-03-08)
+
+## VERIFICATION
+- `curl` returning 200 does NOT mean a frontend works. SPAs serve an HTML shell regardless of whether React components render. The only reliable check is `bun run build`.
+- Never claim a dev server is running without checking `lsof -i :<port>`.
+- You cannot visually verify a frontend. After the build passes and dev server starts, tell the user it's ready — don't claim it "looks good."
+
+## DEPENDENCY MANAGEMENT
+- When `bun install` fails, try at most 2 approaches before asking the user. Do not rabbit-hole into manual tar extraction, rm -rf node_modules, or obscure npm flags.
+- Never `rm -rf node_modules` without user approval.
+
+## ESCALATION
+- If you've tried 2 things and they haven't worked, stop and ask. The user would rather hear "I'm stuck, here's what I tried" than watch 15 minutes of increasingly desperate hacks.

--- a/skills/tools-and-apis/policyengine-app-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-app-skill/SKILL.md
@@ -69,6 +69,39 @@ bun run build                        # Production build
 bun run test                         # Tests
 ```
 
+## CRITICAL: Frontend verification and troubleshooting
+
+### How to verify the frontend works
+
+The ONLY reliable way to verify the frontend compiles correctly is `bun run build`. This catches import errors, TypeScript errors, and missing dependencies.
+
+**`curl` is NOT verification.** Vite serves an HTML shell regardless of whether React components actually render. A 200 from curl means nothing for an SPA. Never use curl output as evidence that the frontend works.
+
+**You cannot visually verify a frontend.** After the build passes and dev server starts, tell the user it's ready for them to check in the browser. Do not claim it "looks good."
+
+Before making any claim about dev server status, check with `lsof -i :5173`. Do not assume it is running.
+
+### Correct verification sequence
+
+```bash
+bun run build                        # Catches all compile-time errors
+# If build passes and dev server needed:
+cd app && VITE_APP_MODE=website ./node_modules/.bin/vite --port 5173 &
+open http://localhost:5173/us         # User checks visually
+```
+
+### Dependency troubleshooting
+
+When `bun install` fails:
+
+1. Read the error. Fix the specific issue.
+2. Try at most **2 approaches** before asking the user for help.
+3. **Hard stops — never do these:**
+   - `rm -rf node_modules` without user approval
+   - Manually `npm pack` + `tar -xzf` packages into node_modules
+   - Editing lockfile internals
+   - Looping through increasingly obscure npm/bun flags
+
 ## Design tokens
 
 Import from `@/designTokens` (convenience layer that re-exports from the design-system package):


### PR DESCRIPTION
## Summary

Adds guardrails to the app skill and agent lessons to prevent three failure modes observed in a real Sonnet session:

- **Fake verification**: Agent used `curl` to claim the frontend worked, but curl can't detect SPA rendering errors. Now requires `bun run build` as the verification method.
- **False claims**: Agent said "dev server is already running" without checking. Now requires `lsof -i :5173` before making claims.
- **Dependency rabbit-holes**: Agent spent 15+ minutes on increasingly desperate hacks (manual tar extraction, rm -rf node_modules, obscure npm flags) instead of asking the user. Now limits troubleshooting to 2 attempts before escalating.

## Test plan

- [ ] Verify the app skill loads correctly with `claude --plugin-dir .`
- [ ] Confirm agent-lessons.md parses without errors