### PR TITLE
Eval-driven improvements to technical-patterns skills

### DIFF
--- a/changelog.d/eval-driven-skill-improvements.changed.md
+++ b/changelog.d/eval-driven-skill-improvements.changed.md
@@ -1,0 +1,1 @@
+Eval-driven improvements to parameter-patterns, variable-patterns, and code-style skills based on RI CCAP test run

--- a/skills/technical-patterns/policyengine-code-style-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-code-style-skill/SKILL.md
@@ -147,6 +147,20 @@ def formula(spm_unit, period, parameters):
     return age_eligible & income_eligible
 ```
 
+### Use Framework Constants, Not Custom Parameters
+
+PolicyEngine provides constants for universal conversion factors. Don't create parameters for these:
+
+```python
+# ❌ BAD — created a weeks_per_month.yaml parameter:
+weekly_subsidy * p.weeks_per_month
+
+# ✅ GOOD — use framework constants:
+weekly_subsidy * (WEEKS_IN_YEAR / MONTHS_IN_YEAR)
+```
+
+Available constants: `MONTHS_IN_YEAR` (12), `WEEKS_IN_YEAR` (52). Derive others from these.
+
 ---
 
 ## Pattern 6: Streamline Variable Access

--- a/skills/technical-patterns/policyengine-parameter-patterns-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-parameter-patterns-skill/SKILL.md
@@ -31,10 +31,20 @@ metadata:
 ## 1. File Naming Conventions
 
 ### Study Reference Implementations First
-Before naming, examine:
-- DC TANF: `/parameters/gov/states/dc/dhs/tanf/`
-- IL TANF: `/parameters/gov/states/il/dhs/tanf/`
-- TX TANF: `/parameters/gov/states/tx/hhs/tanf/`
+**Before creating ANY parameter files, read 3-5 files from a similar program in another state.** Match their structure — don't invent your own. This is the single most effective way to produce correct parameter files.
+
+Search broadly by program concept (not just program name):
+```bash
+# For a childcare program, search by concept keywords:
+Glob 'policyengine_us/parameters/gov/states/*/*/*child*care*/'
+Glob 'policyengine_us/parameters/gov/states/*/*/*ccap*/'
+Glob 'policyengine_us/parameters/gov/states/*/*/*ccfa*/'
+```
+
+Good references by program type:
+- **TANF**: DC, IL, TX — `/parameters/gov/states/{st}/{agency}/tanf/`
+- **Childcare**: MA CCFA, CO CCAP — `/parameters/gov/states/{st}/{agency}/ccfa/` or `ccap/`
+- **LIHEAP**: AZ — `/parameters/gov/states/az/{agency}/liheap/`
 
 ### Naming Patterns
 
@@ -99,6 +109,18 @@ description: [State] provides this amount as the payment standard under the Temp
 **For disregards:**
 ```yaml
 description: [State] excludes this share of earnings from countable income under the Temporary Assistance for Needy Families program.
+```
+
+### Keep Descriptions Practical
+
+Descriptions should focus on what matters for simulation, not copy regulatory language verbatim. Omit regulatory details that have no practical impact:
+
+```yaml
+# ❌ Too literal — no one simulates a 1-week-old:
+description: Rhode Island defines the infant/toddler age range as 1 week up to 3 years under the Child Care Assistance Program.
+
+# ✅ Practical:
+description: Rhode Island defines the infant/toddler age range as up to 3 years under the Child Care Assistance Program.
 ```
 
 ### Description Validation Checklist
@@ -192,6 +214,17 @@ label: California SNAP resource limit
 2. Must contain the actual value
 3. **Title: Include FULL section path** (all subsections and sub-subsections)
 4. **PDF links: Add `#page=XX` at end of href ONLY** (never in title)
+5. **Verify page numbers** — open the PDF and confirm the page number is correct before using it
+
+**Reference Source Hierarchy — prefer online over PDF:**
+1. **Online statute/regulation** (best): Cornell LII, state legislature sites, public.law
+   - Example: `https://www.law.cornell.edu/regulations/rhode-island/218-RICR-20-00-4.6`
+2. **Official government HTML page**: `.gov` pages with section anchors
+3. **PDF with verified page number** (last resort): Only when no online HTML version exists
+   - Rate schedules, policy manuals without HTML versions
+   - Always verify the `#page=XX` is correct
+
+Why: Online references are linkable, searchable, and don't require page number verification. PDF page numbers are error-prone (file page vs printed page) and links break when documents are updated.
 
 **Title Format - Include ALL subsection levels (NO page numbers):**
 ```yaml
@@ -514,6 +547,12 @@ brackets:
       2024-01-01: 0.07
 ```
 
+**BOUNDARY CHECK — do this for every bracket parameter:**
+1. Read the regulation's exact wording for each threshold
+2. If it says "above X" or "more than X" → shift by 0.0001
+3. If it says "at or above X" or "X or more" → no shift needed
+4. Apply consistently to ALL thresholds in the bracket
+
 **When to apply the 0.0001 shift:**
 - Regulation says "above X%" or "more than X%" (exclusive of the boundary)
 - Apply consistently to ALL thresholds in the bracket, not just the first
@@ -521,6 +560,80 @@ brackets:
 **When NOT to shift:**
 - Regulation says "at or above X%" or "X% or more" (inclusive — matches PolicyEngine's default)
 - Regulation says "at least X%" (inclusive)
+
+### Multi-Dimensional Rate Tables (Enum Breakdowns)
+
+**When a rate table has multiple dimensions (e.g., age group × star rating × authorization level), use Enum breakdowns in a small number of parameter files — NOT one file per combination.**
+
+**❌ BAD — 45 files (one per age × time level):**
+```
+rates/licensed_center/infant/full_time.yaml      # breakdown: [star_rating]
+rates/licensed_center/infant/half_time.yaml
+rates/licensed_center/toddler/full_time.yaml
+... (16 files for center alone, 45 total)
+```
+
+**✅ GOOD — 3 files (one per provider type) with multi-dimensional Enum breakdowns:**
+```
+rates/licensed_center.yaml     # breakdown: [time_category, star_rating, age_group]
+rates/licensed_family.yaml     # breakdown: [time_category, star_rating, age_group]
+rates/license_exempt.yaml      # breakdown: [time_category, step_rating, age_group]
+```
+
+**Example rate file with 3D Enum breakdown:**
+```yaml
+# rates/licensed_center.yaml
+description: Rhode Island provides these weekly reimbursement rates for licensed child care centers under the Child Care Assistance Program.
+metadata:
+  period: week
+  unit: currency-USD
+  label: Rhode Island CCAP licensed center weekly rates
+  breakdown:
+    - ri_ccap_time_category
+    - ri_ccap_star_rating
+    - ri_ccap_center_age_group
+  reference:
+    - title: 218-RICR-20-00-4.12
+      href: https://www.law.cornell.edu/regulations/rhode-island/218-RICR-20-00-4.12
+
+FULL_TIME:
+  STAR_1:
+    INFANT:
+      2025-07-01: 334
+    TODDLER:
+      2025-07-01: 278
+    PRESCHOOL:
+      2025-07-01: 236
+    SCHOOL_AGE:
+      2025-07-01: 210
+  STAR_2:
+    INFANT:
+      2025-07-01: 341
+    ...
+```
+
+**The variable lookup becomes simple Enum indexing:**
+```python
+p.licensed_center[time_category][star_rating][center_age]
+```
+
+**When dimensions differ by category** (e.g., licensed centers have 4 age groups, family care has 3):
+- Use separate Enum variables per category (`ri_ccap_center_age_group`, `ri_ccap_family_age_group`)
+- Each rate file references the appropriate Enum in its breakdown
+- The variable uses `select()` on the top-level category (provider type) — each branch uses its own Enums
+
+**When quality ratings differ** (e.g., star ratings 1-5 for licensed, step ratings 1-4 for exempt):
+- Use separate Enum variables (`ri_ccap_star_rating`, `ri_ccap_step_rating`)
+- Each rate file references the appropriate Enum
+
+**Rule of thumb:** If you need helper functions in the variable to do the rate lookup, your parameter structure is too granular. Restructure the parameters.
+
+### Don't Create Unnecessary Parameters
+
+**Don't create parameters for:**
+- **Universal conversion factors** — Use framework constants instead. `WEEKS_IN_YEAR / MONTHS_IN_YEAR` gives weeks-per-month. `MONTHS_IN_YEAR` gives 12. Don't create a `weeks_per_month.yaml` parameter.
+- **Thresholds with no practical simulation impact** — A minimum age of "1 week" for childcare has no simulation value. No one models newborns. Skip it.
+- **Values derivable from existing parameters** — If FPL tables already exist, don't recreate them as program-specific parameters.
 
 ### Parameter Structure Transitions (Flat → Bracket)
 

--- a/skills/technical-patterns/policyengine-variable-patterns-skill/SKILL.md
+++ b/skills/technical-patterns/policyengine-variable-patterns-skill/SKILL.md
@@ -810,6 +810,51 @@ Before creating any enum variable, check:
 2. Does an existing input variable provide the numeric value? (Grep the codebase)
 3. If yes to both → use a bracket parameter + formula, not a bare input
 
+### Rate Table Dimensions: One Enum Variable Per Dimension
+
+**When a rate table has multiple dimensions (provider type, age group, star rating, authorization level), create a separate Enum variable for each dimension.** This enables simple Enum bracket indexing in the rate lookup variable.
+
+**Pattern:**
+```python
+# Each dimension is its own Enum variable:
+provider_type = person("ri_ccap_provider_type", period)
+time_category = person("ri_ccap_time_category", period)
+star_rating = person("ri_ccap_star_rating", period)
+age_group = person("ri_ccap_center_age_group", period)
+
+# Rate lookup is just Enum indexing:
+rate = p.licensed_center[time_category][star_rating][age_group]
+```
+
+**When dimensions differ by category, use separate Enums:**
+- Licensed centers have 4 age groups (Infant, Toddler, Preschool, School Age)
+- Family child care has 3 age groups (Infant/Toddler, Preschool, School Age)
+- → Create `ri_ccap_center_age_group` and `ri_ccap_family_age_group`
+
+**When quality ratings differ by provider type:**
+- Licensed centers/family use star ratings (1-5)
+- License-exempt uses step ratings (1-4)
+- → Create `ri_ccap_star_rating` and `ri_ccap_step_rating` as separate Enums
+
+**Use Enum (not int) for constrained categories:**
+```python
+# ❌ BAD — star rating as int (what values are valid? unclear)
+class ri_ccap_star_rating(Variable):
+    value_type = int
+
+# ✅ GOOD — star rating as Enum (self-documenting, validated)
+class RICCAPStarRating(Enum):
+    STAR_1 = "1 Star"
+    STAR_2 = "2 Stars"
+    STAR_3 = "3 Stars"
+    STAR_4 = "4 Stars"
+    STAR_5 = "5 Stars"
+```
+
+**If you need helper functions in a rate lookup, your parameter structure is too granular.** Restructure the parameter files to use Enum breakdowns (see parameter-patterns skill) so the variable is just `select()` + indexing.
+
+**Reference implementation:** MA CCFA reimbursement — `ma_ccfa_center_based_early_education_reimbursement.py` is 3 lines: get region, get age category, index into parameter.
+
 #### State Variables to AVOID Creating
 
 For TANF implementations:


### PR DESCRIPTION
## Summary

Improves 3 technical-patterns skills based on a full eval run of the `encode-policy-v2` command on Rhode Island CCAP (Child Care Assistance Program).

## Eval Methodology

1. Researched RI CCAP regulations (218-RICR-20-00-4) and provider payment rates
2. Spawned rules-engineer agents via agent teams to create parameters (55 files) and variables (15 files)
3. Reviewed output against reference branch and regulatory sources
4. Identified 12 issues, traced each to a skill gap, and fixed them

## Issues Found and Fixed

| # | Issue | Skill Fixed |
|---|-------|------------|
| 1 | Wrong PDF page numbers, should prefer online refs (Cornell LII) | parameter-patterns |
| 2 | Missing 0.0001 bracket boundary shift despite being documented | parameter-patterns |
| 3 | Orphaned parameters (created but unused by variables) | parameter-patterns |
| 4 | Unnecessary parameter (min_age_weeks — no simulation value) | parameter-patterns |
| 5 | Star rating as int instead of Enum | variable-patterns |
| 6 | Missing child age category Enum variable | variable-patterns |
| 7 | weeks_per_month parameter instead of framework constants | code-style |
| 8 | Over-granular rate files (45 files → 3 with Enum breakdowns) | parameter-patterns |
| 9 | Helper functions in rate lookup (sign of bad param structure) | variable-patterns |
| 10 | Didn't follow reference implementation patterns deeply enough | parameter-patterns |
| 11 | Authorization level should be Enum breakdown dimension | parameter-patterns + variable-patterns |
| 12 | Descriptions too literal — copied regulatory language verbatim | parameter-patterns |

## Changes by Skill

**parameter-patterns** (+121 lines):
- Reference source hierarchy: online statute > government HTML > PDF with verified page number
- Strengthened bracket boundary 0.0001 shift with explicit 4-step BOUNDARY CHECK
- New "Multi-Dimensional Rate Tables" section with full Enum breakdown example
- New "Don't Create Unnecessary Parameters" section
- Strengthened "Study Reference Implementations First" with broad search patterns
- Added "Keep Descriptions Practical" guidance

**variable-patterns** (+45 lines):
- New "Rate Table Dimensions: One Enum Variable Per Dimension" section
- Guidance on separate Enums when dimensions differ by category
- Enum vs int: use Enum for constrained categories, int only for arithmetic
- Helper function warning: restructure parameters instead

**code-style** (+14 lines):
- Framework constants guidance: use WEEKS_IN_YEAR / MONTHS_IN_YEAR, not custom parameters

## Test plan
- [ ] Verify skill files parse correctly (valid YAML frontmatter)
- [ ] Review new examples for accuracy against PolicyEngine patterns
- [ ] Consider a re-run of RI CCAP eval to verify improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)