### PR TITLE
Add unreachable reference checkpoint to encode-policy-v2

### DIFF
--- a/changelog.d/unreachable-ref-checkpoint.added.md
+++ b/changelog.d/unreachable-ref-checkpoint.added.md
@@ -1,0 +1,1 @@
+Add unreachable reference checkpoint to encode-policy-v2 — after document collection, presents failed-to-fetch URLs to user for manual download before proceeding to implementation.

--- a/commands/encode-policy-v2.md
+++ b/commands/encode-policy-v2.md
@@ -94,6 +94,7 @@ run_in_background: true
   - Number of income deductions/exemptions found
   - Benefit calculation type (flat, formula, tiered)
   - Complexity hint (simple/complex)
+  - **Failed fetches**: list any URLs that returned 403, redirected, or timed out (with a brief description of what they likely contain)
 
 RULES:
 - PDF hrefs include #page=XX (file page number, NOT printed page number)
@@ -108,6 +109,36 @@ After both agents complete:
 - Report brief status to user
 
 **Stop here if document-collector failed** — cannot proceed without documentation.
+
+### Step 0E: Unreachable Reference Checkpoint (USER CHECKPOINT)
+
+After document-collector completes, check its research summary for any references that **failed to fetch** (403, redirect, timeout, connection refused). State agency websites (e.g., NH DHHS, many .gov sites) commonly block automated access while working fine in a browser.
+
+**If unreachable references exist**, present them to the user using `AskUserQuestion`:
+
+```
+AskUserQuestion:
+  Question: "The document collector could not access these references automatically. Please check them in your browser — if any contain useful data (rate tables, cost share schedules, policy changes), download them and send the file paths."
+  Header: "References"
+  Options:
+    - "I'll download and send files" — wait for user to provide file paths, then re-run document-collector or have a general-purpose agent extract text/screenshots from the user-provided PDFs into sources/working_references.md
+    - "Skip these, proceed with what we have" — continue to Phase 1 with available documentation only
+    - "Let me check first" — pause and wait for user to investigate
+```
+
+**Common unreachable reference types** (look for these in the collector's failed-fetch list):
+- State agency rate schedules (e.g., BCDHSC Form 2533 for rates, Form 2532 for cost share)
+- Supervisory Release (SR) announcements (policy change documents)
+- Policy manual sections (FAM topics)
+- Provider enrollment/billing pages
+
+**If user provides files**, process them before proceeding:
+1. Copy to `/tmp/{PREFIX}-user-doc-{N}.pdf`
+2. Extract text: `pdftotext /tmp/{PREFIX}-user-doc-{N}.pdf /tmp/{PREFIX}-user-doc-{N}.txt`
+3. Render screenshots: `pdftoppm -png -r {DPI} /tmp/{PREFIX}-user-doc-{N}.pdf /tmp/{PREFIX}-user-doc-{N}-page`
+4. Have a general-purpose agent append the new content to `sources/working_references.md`
+
+**If no unreachable references**, skip this step and proceed to Phase 1.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a user checkpoint (Step 0E) to the `/encode-policy-v2` command that surfaces references the document-collector could not automatically fetch (403, redirect, timeout). The user can then manually download and provide these files before the consolidation phase begins.

## Motivation

During NH CCAP implementation, the document-collector found URLs for the official rate schedule (BCDHSC Form 2533) and cost share table (Form 2532/SR 24-08) but couldn't fetch them — NH DHHS returns 403 for automated requests while working fine in a browser. The agents fell back on the CCDF State Plan and Cornell LII, which had incomplete/outdated data:

- **24 of 45 rate values were wrong** — HT/PT rates assumed FT/2 and FT/4, but actual ratios are ~77.4% and ~38.7%
- **Cost share structure** was only partially captured from the State Plan text
- **Exempt center rules** (school-age base rate, 72-month age guard) were missing

All of this was only discovered after the user manually downloaded Form 2533 and compared values.

## Changes

1. **Step 0E added** after document-collector completes (Phase 0D) and before consolidation (Phase 1)
2. **Document-collector prompt updated** to report failed fetches in the research summary
3. **User presented with AskUserQuestion** listing unreachable URLs with options to download/skip/investigate
4. **If user provides files**, they are processed (text extraction + screenshots) and appended to working_references.md before consolidation

## Common blocked sources (by state agency)

| Agency | Blocked Content |
|--------|----------------|
| NH DHHS | Rate schedules (Form 2533), cost share tables (Form 2532), SR announcements, policy manual |
| Many .gov sites | Provider enrollment pages, sliding fee schedules, operational forms |