### PR TITLE
Document federal/state benefit cost attribution in skills

### DIFF
--- a/changelog.d/document-federal-state-benefit-cost.added.md
+++ b/changelog.d/document-federal-state-benefit-cost.added.md
@@ -1,0 +1,1 @@
+Document Medicaid/CHIP federal vs. state cost attribution variables in healthcare and microsimulation skills.

--- a/skills/domain-knowledge/policyengine-healthcare-skill/SKILL.md
+++ b/skills/domain-knowledge/policyengine-healthcare-skill/SKILL.md
@@ -58,6 +58,9 @@ Most benefit programs (SNAP, TANF, EITC) have a single income test and a single 
 | `medicaid_magi` | tax_unit | Modified AGI for Medicaid (= AGI + state additions) |
 | `takes_up_medicaid_if_eligible` | person | Pseudo-random take-up flag (default rate: 93%) |
 | `medicaid_cost` | person | Per-capita cost by eligibility group and state |
+| `medicaid_federal_share` | person | Applicable FMAP: 90% for expansion adults (42 USC 1396d(y)), state regular FMAP otherwise (42 USC 1396d(b)) |
+| `medicaid_federal_cost` | person | Federal portion of `medicaid_cost` (= cost × FMAP) |
+| `medicaid_state_cost` | person | State portion of `medicaid_cost` (= cost × (1 − FMAP)) |
 
 #### ACA marketplace
 
@@ -76,8 +79,21 @@ Most benefit programs (SNAP, TANF, EITC) have a single income test and a single 
 | Variable | Entity | Description |
 |----------|--------|-------------|
 | `per_capita_chip` | person | CHIP benefit per capita |
-| `is_chip_eligible` | person | CHIP eligibility |
+| `chip` | person | Annual CHIP benefit (= `per_capita_chip` when enrolled) |
+| `is_chip_eligible` | person | CHIP eligibility (requires `~is_medicaid_eligible` — mutually exclusive with Medicaid) |
 | `chip_category` | person | Enum: CHILD, PREGNANT_STANDARD, PREGNANT_FCEP, NONE |
+| `chip_federal_share` | person | Enhanced FMAP per 42 USC 1397ee(b): `min(FMAP + 30% × (1 − FMAP), 0.85)` |
+| `chip_federal_cost` | person | Federal portion of `chip` (= chip × eFMAP) |
+| `chip_state_cost` | person | State portion of `chip` (= chip × (1 − eFMAP)) |
+
+#### Cross-program federal/state attribution
+
+For consumer-facing fiscal impact analysis, aggregate variables sum across all programs with federal/state attribution (currently Medicaid and CHIP; will extend as SNAP, TANF, etc. get attribution):
+
+| Variable | Entity | Description |
+|----------|--------|-------------|
+| `federal_benefit_cost` | person | Sum of federal portions across all attributed programs |
+| `state_benefit_cost` | person | Sum of state portions across all attributed programs |
 
 ### Household setup for healthcare analysis
 

--- a/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
+++ b/skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md
@@ -349,6 +349,25 @@ print(f"State/local tax revenue loss: ${state_tax_cost:,.1f}B")
 print(f"Benefit spending increase: ${benefit_cost:,.1f}B")
 ```
 
+### Federal vs. state benefit cost attribution
+
+Benefit programs with shared federal/state funding (Medicaid, CHIP; SNAP starting FY2028 under OBBBA) attribute cost per statute. Use `federal_benefit_cost` and `state_benefit_cost` to split benefit spending by level of government:
+
+```python
+# Federal share of benefit spending (Medicaid via FMAP, CHIP via eFMAP, …)
+fed_benefit_change = (reformed.calc('federal_benefit_cost', period=YEAR).sum() -
+                      baseline.calc('federal_benefit_cost', period=YEAR).sum()) / 1e9
+
+# State share
+state_benefit_change = (reformed.calc('state_benefit_cost', period=YEAR).sum() -
+                        baseline.calc('state_benefit_cost', period=YEAR).sum()) / 1e9
+
+print(f"Federal benefit cost change: ${fed_benefit_change:+.1f}B")
+print(f"State benefit cost change:   ${state_benefit_change:+.1f}B")
+```
+
+Per-program attribution is also available: `medicaid_federal_cost` / `medicaid_state_cost`, `chip_federal_cost` / `chip_state_cost`. The federal share comes from FMAP (42 USC 1396d(b), 90% for ACA expansion adults per 1396d(y)) and eFMAP for CHIP (42 USC 1397ee(b)). This is the right split for scoring reforms that affect Medicaid/CHIP participation — a rollback that reduces Medicaid spending by $X shifts a smaller amount to states and a larger amount to the federal government depending on state FMAPs.
+
 **Why not sum the program variable directly?** Example: making the CTC fully refundable
 shifts credits from non-refundable to refundable, changing `income_tax` by much more than
 the `ctc` variable itself changes. The `household_net_income` change captures the full effect.


### PR DESCRIPTION
## Summary

Documents the new Medicaid + CHIP federal/state cost attribution variables (landing in PolicyEngine/policyengine-us#8076) in the healthcare and microsimulation skills, so Claude suggests them when users ask about fiscal impact of benefit reforms.

## Changes

- **`skills/domain-knowledge/policyengine-healthcare-skill/SKILL.md`**: adds table entries for `medicaid_federal_share` / `medicaid_federal_cost` / `medicaid_state_cost`, `chip` / `chip_federal_share` / `chip_federal_cost` / `chip_state_cost`, and a new "Cross-program federal/state attribution" section introducing `federal_benefit_cost` / `state_benefit_cost`.
- **`skills/tools-and-apis/policyengine-microsimulation-skill/SKILL.md`**: adds a "Federal vs. state benefit cost attribution" section with example code showing how to aggregate federal/state benefit spending across a reform, complementing the existing federal vs. state tax revenue example.

## Why

PolicyEngine-US #8076 adds `medicaid_federal_cost` etc. When users ask "what's the federal fiscal impact of this Medicaid reform?" Claude should pull in the correct attribution variables rather than falling back on a single `budgetary_impact` number that conflates federal and state.

## Related

- PolicyEngine/policyengine-us#8075 (broad scoping)
- PolicyEngine/policyengine-us#8076 (Medicaid + CHIP attribution)
- PolicyEngine/policyengine-api#3481 (API follow-up)
- PolicyEngine/policyengine-app-v2#999 (UI follow-up)
